### PR TITLE
refactor(headers): isolate request headers from HTTP request headers

### DIFF
--- a/pkg/engines/client/http.go
+++ b/pkg/engines/client/http.go
@@ -87,19 +87,12 @@ func (e *HTTPEndpoint) Process(req *octollm.Request) (*octollm.Response, error) 
 		return nil, fmt.Errorf("new request error: %w", err)
 	}
 
-	httpReq.Header.Set("Content-Type", "application/json")
-
-	for k, v := range req.Header {
-		// http.Client handles its own compression
-		if k == "Accept-Encoding" {
-			continue
-		}
-		for _, vv := range v {
-			httpReq.Header.Add(k, vv)
-		}
-	}
+	httpReq.Header = req.Header
 	if e.reqModifier != nil {
 		httpReq = e.reqModifier(req, httpReq)
+	}
+	if httpReq.Header.Get("Content-Type") == "" {
+		httpReq.Header.Set("Content-Type", "application/json")
 	}
 
 	resp, err := e.client.Do(httpReq)

--- a/pkg/octollm/handler.go
+++ b/pkg/octollm/handler.go
@@ -19,8 +19,9 @@ import (
 type contextKey string
 
 const (
-	ContextKeyModelName contextKey = "model_name"
-	ContextKeyAction    contextKey = "action"
+	ContextKeyModelName      contextKey = "model_name"
+	ContextKeyAction         contextKey = "action"
+	ContextKeyReceivedHeader contextKey = "received_header"
 )
 
 type Server struct {
@@ -44,6 +45,8 @@ func (s *Server) SetEngine(ep Engine) {
 // Otherwise, it will write the response as a plain text.
 func httpSSEHandler(engine Engine, format APIFormat, parser Parser) http.HandlerFunc {
 	return errutils.ErrorHandlingMiddleware(func(w http.ResponseWriter, r *http.Request) {
+		// store received headers in context
+		r = r.WithContext(context.WithValue(r.Context(), ContextKeyReceivedHeader, r.Header))
 		u := NewRequest(r, format)
 		u.Body.SetParser(parser)
 		resp, err := engine.Process(u)
@@ -145,6 +148,8 @@ func RerankHandler(engine Engine) http.HandlerFunc {
 // This is the format used by Google Vertex AI API.
 func httpJSONArrayHandler(engine Engine, format APIFormat, parser Parser) http.HandlerFunc {
 	return errutils.ErrorHandlingMiddleware(func(w http.ResponseWriter, r *http.Request) {
+		// store received headers in context
+		r = r.WithContext(context.WithValue(r.Context(), ContextKeyReceivedHeader, r.Header))
 		u := NewRequest(r, format)
 		u.Body.SetParser(parser)
 		resp, err := engine.Process(u)

--- a/pkg/octollm/request.go
+++ b/pkg/octollm/request.go
@@ -214,7 +214,7 @@ func NewRequest(r *http.Request, format APIFormat) *Request {
 		Format: format,
 		URL:    r.URL,
 		Query:  r.URL.Query(),
-		Header: r.Header,
+		Header: make(http.Header),
 		ctx:    r.Context(),
 		Body: &UnifiedBody{
 			reader: r.Body,


### PR DESCRIPTION
- Store original HTTP headers in context (ContextKeyReceivedHeader)
- Initialize Request objects with empty headers to prevent mutation
- Simplify HTTPEndpoint header handling with direct assignment
- Set Content-Type only if not present after reqModifier runs

This prevents unintended header sharing and allows proper header manipulation through the engine chain.