### PR TITLE
feat(metadata): add Response.Metadata for usage report

### DIFF
--- a/pkg/engines/client/http.go
+++ b/pkg/engines/client/http.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/infinigence/octollm/pkg/errutils"
 	"github.com/infinigence/octollm/pkg/octollm"
@@ -22,6 +23,26 @@ const (
 	StreamingTypeSSE  StreamingType = "sse"
 	StreamingTypeJSON StreamingType = "json"
 )
+
+type clientMetadataKey string
+
+const (
+	// clientRecvFirstChunkTime stores the timestamp (time.Time) when the first chunk
+	// was received from the upstream HTTP endpoint.
+	clientRecvFirstChunkTime clientMetadataKey = "recv_first_chunk_time"
+)
+
+func GetClientRecvFirstChunkTime(resp *octollm.Response) (time.Time, bool) {
+	if resp == nil {
+		return time.Time{}, false
+	}
+	value, ok := resp.GetMetadataValue(clientRecvFirstChunkTime)
+	if !ok {
+		return time.Time{}, false
+	}
+	t, ok := value.(time.Time)
+	return t, ok
+}
 
 type HTTPEndpoint struct {
 	client          *http.Client
@@ -145,29 +166,37 @@ func (e *HTTPEndpoint) Process(req *octollm.Request) (*octollm.Response, error) 
 	// stream response
 	ch := make(chan *octollm.StreamChunk)
 	ctx, cancel := context.WithCancel(req.Context())
+	streamChan := octollm.NewStreamChan(ch, cancel)
+	llmresp := octollm.NewStreamResponse(resp.StatusCode, resp.Header, streamChan)
+
+	setRecvFirstChunkTime := func(recvTime time.Time) {
+		llmresp.SetMetadataValue(clientRecvFirstChunkTime, recvTime)
+	}
+
 	// use a scanner to read SSE messages
 	streamParser, streamingType := e.streamParser(req)
 	switch streamingType {
 	case StreamingTypeSSE:
-		go e.processSSEStream(ctx, resp, ch, streamParser)
+		go e.processSSEStream(ctx, resp, ch, streamParser, setRecvFirstChunkTime)
 	case StreamingTypeJSON:
-		go e.processJSONStream(ctx, resp, ch, streamParser)
+		go e.processJSONStream(ctx, resp, ch, streamParser, setRecvFirstChunkTime)
 	default:
+		cancel() // just for the linter
 		return nil, fmt.Errorf("unsupported streaming type %s", streamingType)
 	}
 
 	logrus.WithContext(req.Context()).Debugf("[http-endpoint] returning stream response")
-	streamChan := octollm.NewStreamChan(ch, cancel)
-	llmresp := octollm.NewStreamResponse(resp.StatusCode, resp.Header, streamChan)
 	return llmresp, nil
 }
 
-func (e *HTTPEndpoint) processSSEStream(ctx context.Context, resp *http.Response, ch chan *octollm.StreamChunk, streamParser octollm.Parser) {
+func (e *HTTPEndpoint) processSSEStream(ctx context.Context, resp *http.Response, ch chan *octollm.StreamChunk, streamParser octollm.Parser, setRecvFirstChunkTime func(recvTime time.Time)) {
 	defer close(ch)
 	defer resp.Body.Close()
 
 	metaBuffer := make(map[string]string)
 	bodyBuffer := make([]byte, 0, 512)
+
+	var recvFirstChunkTime time.Time
 
 	scanner := bufio.NewScanner(resp.Body)
 	for scanner.Scan() {
@@ -211,6 +240,10 @@ func (e *HTTPEndpoint) processSSEStream(ctx context.Context, resp *http.Response
 
 		switch key {
 		case "data":
+			if recvFirstChunkTime.IsZero() {
+				recvFirstChunkTime = time.Now()
+				setRecvFirstChunkTime(recvFirstChunkTime)
+			}
 			// find the first non-space byte
 			start := slices.IndexFunc(line[colonIdx+1:], func(b byte) bool {
 				return b != ' '
@@ -231,7 +264,7 @@ func (e *HTTPEndpoint) processSSEStream(ctx context.Context, resp *http.Response
 	}
 }
 
-func (e *HTTPEndpoint) processJSONStream(ctx context.Context, resp *http.Response, ch chan *octollm.StreamChunk, streamParser octollm.Parser) {
+func (e *HTTPEndpoint) processJSONStream(ctx context.Context, resp *http.Response, ch chan *octollm.StreamChunk, streamParser octollm.Parser, setRecvFirstChunkTime func(recvTime time.Time)) {
 	defer close(ch)
 	defer resp.Body.Close()
 
@@ -243,12 +276,13 @@ func (e *HTTPEndpoint) processJSONStream(ctx context.Context, resp *http.Respons
 		logrus.WithContext(ctx).Warnf("[http-endpoint] failed to read opening bracket: %v", err)
 		return
 	}
-
 	// Verify it's an array opening bracket
 	if delim, ok := t.(json.Delim); !ok || delim != '[' {
 		logrus.WithContext(ctx).Warnf("[http-endpoint] expected array opening bracket, got %T: %v", t, t)
 		return
 	}
+
+	var recvFirstChunkTime time.Time
 
 	// Read array elements
 	for dec.More() {
@@ -256,12 +290,16 @@ func (e *HTTPEndpoint) processJSONStream(ctx context.Context, resp *http.Respons
 			logrus.WithContext(ctx).Infof("[http-endpoint] context error during JSON stream response: %v", ctx.Err())
 			return
 		}
-
 		// Decode one JSON object into RawMessage to preserve the raw bytes
 		var rawMsg json.RawMessage
 		if err := dec.Decode(&rawMsg); err != nil {
 			logrus.WithContext(ctx).Warnf("[http-endpoint] failed to decode JSON object: %v", err)
 			return
+		}
+
+		if recvFirstChunkTime.IsZero() {
+			recvFirstChunkTime = time.Now()
+			setRecvFirstChunkTime(recvFirstChunkTime)
 		}
 
 		// Create chunk from raw JSON bytes
@@ -278,7 +316,7 @@ func (e *HTTPEndpoint) processJSONStream(ctx context.Context, resp *http.Respons
 	}
 
 	// Read closing bracket ']'
-	t, err = dec.Token()
+	_, err = dec.Token()
 	if err != nil {
 		logrus.WithContext(ctx).Warnf("[http-endpoint] failed to read closing bracket: %v", err)
 		return

--- a/pkg/engines/client/http_test.go
+++ b/pkg/engines/client/http_test.go
@@ -69,7 +69,9 @@ func TestProcessJSONStream(t *testing.T) {
 	defer cancel()
 
 	endpoint := NewHTTPEndpoint()
-	go endpoint.processJSONStream(ctx, resp, ch, parser)
+	go endpoint.processJSONStream(ctx, resp, ch, parser, func(value time.Time) {
+		// no-op for test
+	})
 
 	var chunks []*octollm.StreamChunk
 	done := make(chan bool)

--- a/pkg/engines/load-balancer/round_robin.go
+++ b/pkg/engines/load-balancer/round_robin.go
@@ -33,6 +33,23 @@ type WeightedRoundRobin struct {
 
 var _ octollm.Engine = (*WeightedRoundRobin)(nil)
 
+type loadBalancerMetadataKey string
+
+const (
+	// backendName stores the name of the backend selected by the load balancer.
+	backendName loadBalancerMetadataKey = "backend_name"
+)
+
+// GetSelectedBackendName retrieves the selected backend name from response metadata.
+func GetSelectedBackendName(resp *octollm.Response) (string, bool) {
+	val, ok := resp.GetMetadataValue(backendName)
+	if !ok {
+		return "", false
+	}
+	name, ok := val.(string)
+	return name, ok
+}
+
 func NewWeightedRoundRobin(backends []BackendItem, retryTimeout time.Duration, retryMaxCount int) (*WeightedRoundRobin, error) {
 	if len(backends) == 0 {
 		return nil, fmt.Errorf("backends must have at least one item")
@@ -80,6 +97,7 @@ func (l *WeightedRoundRobin) Process(req *octollm.Request) (*octollm.Response, e
 		logrus.WithContext(req.Context()).Infof("[WRR load balancer] will use engine name: %s", n)
 		resp, err := eng.Process(req)
 		if err == nil {
+			resp.SetMetadataValue(backendName, n)
 			return resp, nil
 		}
 		retryCount++

--- a/pkg/engines/rule-engine/engine.go
+++ b/pkg/engines/rule-engine/engine.go
@@ -32,6 +32,23 @@ type RuleEngine struct {
 
 var _ octollm.Engine = (*RuleEngine)(nil)
 
+type ruleEngineMetadataKey string
+
+const (
+	// matchedRuleName stores the name of the rule that was matched by the rule engine.
+	matchedRuleName ruleEngineMetadataKey = "matched_rule_name"
+)
+
+// GetMatchedRuleName retrieves the matched rule name from response metadata.
+func GetMatchedRuleName(resp *octollm.Response) (string, bool) {
+	val, ok := resp.GetMetadataValue(matchedRuleName)
+	if !ok {
+		return "", false
+	}
+	ruleName, ok := val.(string)
+	return ruleName, ok
+}
+
 func (e *RuleEngine) Process(req *octollm.Request) (*octollm.Response, error) {
 	// find default chain
 	currChain, ok := e.Chains["default"]
@@ -51,6 +68,7 @@ func (e *RuleEngine) Process(req *octollm.Request) (*octollm.Response, error) {
 		logrus.WithContext(req.Context()).Debugf("[rule-engine] rule %s matched, executing", r.Name)
 		resp, err := r.Engine.Process(req)
 		if err == nil {
+			resp.SetMetadataValue(matchedRuleName, r.Name)
 			logrus.WithContext(req.Context()).Debugf("[rule-engine] rule %s exec success", r.Name)
 			return resp, nil
 		}

--- a/pkg/octollm/request.go
+++ b/pkg/octollm/request.go
@@ -179,6 +179,28 @@ type Response struct {
 	Header     http.Header
 	Body       *UnifiedBody
 	Stream     *StreamChan
+
+	// metadata stores engine-specific information that child engines can write
+	// and parent engines can retrieve. Used for passing data up the engine chain
+	// (e.g., retry attempts, selected backend, timing info, custom flags).
+	metadata map[any]any
+}
+
+// GetMetadataValue retrieves a value from metadata by key with type assertion.
+func (r *Response) GetMetadataValue(key any) (any, bool) {
+	if r.metadata == nil {
+		return nil, false
+	}
+	val, ok := r.metadata[key]
+	return val, ok
+}
+
+// SetMetadataValue sets a value in metadata by key. Initializes metadata map if nil.
+func (r *Response) SetMetadataValue(key any, value any) {
+	if r.metadata == nil {
+		r.metadata = make(map[any]any)
+	}
+	r.metadata[key] = value
 }
 
 type StreamChan struct {


### PR DESCRIPTION
Enable engines to pass data up the chain by adding Response.Metadata map. Engines can now record diagnostic info like selected backends, matched rules, and timing metrics.

Changes:
- Add Response.Metadata field with GetMetadataByKey helper
- Track ClientRecvFirstChunkTime in HTTP client streaming
- Record BackendName in load balancer
- Record MatchedRuleName in rule engine