### PR TITLE
refactor: move metadata from Response to Request

### DIFF
--- a/pkg/engines/client/http.go
+++ b/pkg/engines/client/http.go
@@ -32,11 +32,11 @@ const (
 	clientRecvFirstChunkTime clientMetadataKey = "recv_first_chunk_time"
 )
 
-func GetClientRecvFirstChunkTime(resp *octollm.Response) (time.Time, bool) {
-	if resp == nil {
+func GetClientRecvFirstChunkTime(req *octollm.Request) (time.Time, bool) {
+	if req == nil {
 		return time.Time{}, false
 	}
-	value, ok := resp.GetMetadataValue(clientRecvFirstChunkTime)
+	value, ok := req.GetMetadataValue(clientRecvFirstChunkTime)
 	if !ok {
 		return time.Time{}, false
 	}
@@ -170,7 +170,7 @@ func (e *HTTPEndpoint) Process(req *octollm.Request) (*octollm.Response, error) 
 	llmresp := octollm.NewStreamResponse(resp.StatusCode, resp.Header, streamChan)
 
 	setRecvFirstChunkTime := func(recvTime time.Time) {
-		llmresp.SetMetadataValue(clientRecvFirstChunkTime, recvTime)
+		req.SetMetadataValue(clientRecvFirstChunkTime, recvTime)
 	}
 
 	// use a scanner to read SSE messages

--- a/pkg/engines/load-balancer/round_robin.go
+++ b/pkg/engines/load-balancer/round_robin.go
@@ -40,9 +40,9 @@ const (
 	backendName loadBalancerMetadataKey = "backend_name"
 )
 
-// GetSelectedBackendName retrieves the selected backend name from response metadata.
-func GetSelectedBackendName(resp *octollm.Response) (string, bool) {
-	val, ok := resp.GetMetadataValue(backendName)
+// GetSelectedBackendName retrieves the selected backend name from request metadata.
+func GetSelectedBackendName(req *octollm.Request) (string, bool) {
+	val, ok := req.GetMetadataValue(backendName)
 	if !ok {
 		return "", false
 	}
@@ -97,7 +97,7 @@ func (l *WeightedRoundRobin) Process(req *octollm.Request) (*octollm.Response, e
 		slog.InfoContext(req.Context(), fmt.Sprintf("[WRR load balancer] will use engine name: %s", n))
 		resp, err := eng.Process(req)
 		if err == nil {
-			resp.SetMetadataValue(backendName, n)
+			req.SetMetadataValue(backendName, n)
 			return resp, nil
 		}
 		retryCount++

--- a/pkg/engines/rule-engine/engine.go
+++ b/pkg/engines/rule-engine/engine.go
@@ -39,9 +39,9 @@ const (
 	matchedRuleName ruleEngineMetadataKey = "matched_rule_name"
 )
 
-// GetMatchedRuleName retrieves the matched rule name from response metadata.
-func GetMatchedRuleName(resp *octollm.Response) (string, bool) {
-	val, ok := resp.GetMetadataValue(matchedRuleName)
+// GetMatchedRuleName retrieves the matched rule name from request metadata.
+func GetMatchedRuleName(req *octollm.Request) (string, bool) {
+	val, ok := req.GetMetadataValue(matchedRuleName)
 	if !ok {
 		return "", false
 	}
@@ -68,7 +68,7 @@ func (e *RuleEngine) Process(req *octollm.Request) (*octollm.Response, error) {
 		slog.DebugContext(req.Context(), fmt.Sprintf("[rule-engine] rule %s matched, executing", r.Name))
 		resp, err := r.Engine.Process(req)
 		if err == nil {
-			resp.SetMetadataValue(matchedRuleName, r.Name)
+			req.SetMetadataValue(matchedRuleName, r.Name)
 			slog.DebugContext(req.Context(), fmt.Sprintf("[rule-engine] rule %s exec success", r.Name))
 			return resp, nil
 		}

--- a/pkg/octollm/request.go
+++ b/pkg/octollm/request.go
@@ -179,7 +179,29 @@ type Request struct {
 	Header http.Header
 	Body   *UnifiedBody
 
+	// metadata stores engine-specific information that engines can write and read.
+	// Used for passing data through the engine chain
+	// (e.g., retry attempts, selected backend, timing info, custom flags).
+	metadata map[any]any
+
 	ctx context.Context
+}
+
+// GetMetadataValue retrieves a value from metadata by key with type assertion.
+func (u *Request) GetMetadataValue(key any) (any, bool) {
+	if u.metadata == nil {
+		return nil, false
+	}
+	val, ok := u.metadata[key]
+	return val, ok
+}
+
+// SetMetadataValue sets a value in metadata by key. Initializes metadata map if nil.
+func (u *Request) SetMetadataValue(key any, value any) {
+	if u.metadata == nil {
+		u.metadata = make(map[any]any)
+	}
+	u.metadata[key] = value
 }
 
 type Response struct {
@@ -187,28 +209,6 @@ type Response struct {
 	Header     http.Header
 	Body       *UnifiedBody
 	Stream     *StreamChan
-
-	// metadata stores engine-specific information that child engines can write
-	// and parent engines can retrieve. Used for passing data up the engine chain
-	// (e.g., retry attempts, selected backend, timing info, custom flags).
-	metadata map[any]any
-}
-
-// GetMetadataValue retrieves a value from metadata by key with type assertion.
-func (r *Response) GetMetadataValue(key any) (any, bool) {
-	if r.metadata == nil {
-		return nil, false
-	}
-	val, ok := r.metadata[key]
-	return val, ok
-}
-
-// SetMetadataValue sets a value in metadata by key. Initializes metadata map if nil.
-func (r *Response) SetMetadataValue(key any, value any) {
-	if r.metadata == nil {
-		r.metadata = make(map[any]any)
-	}
-	r.metadata[key] = value
 }
 
 type StreamChan struct {


### PR DESCRIPTION
Engine-specific metadata (backend name, matched rule, timing) now lives on the Request so it persists across the engine chain and is accessible by any engine or middleware without needing to thread the Response back up.