### PR TITLE
fix(rewrite): revert request body when downstream engine fails

### DIFF
--- a/pkg/engines/rewrite.go
+++ b/pkg/engines/rewrite.go
@@ -123,6 +123,7 @@ func NewRewriteEngine(next octollm.Engine, requestRewrite, nonstreamResponseRewr
 }
 
 func (e *RewriteEngine) Process(req *octollm.Request) (*octollm.Response, error) {
+	shouldRevertRewrite := false
 	if e.RequestRewrite != nil {
 		exprEnv := exprenv.Get(req)
 
@@ -136,6 +137,14 @@ func (e *RewriteEngine) Process(req *octollm.Request) (*octollm.Response, error)
 			return nil, fmt.Errorf("get request body bytes error: %w", err)
 		}
 		req.Body.SetBytes(reqRewriter.RewriteJSON(b))
+		shouldRevertRewrite = true
+		defer func() {
+			if shouldRevertRewrite {
+				// revert the rewrite to make sure the original request body is not changed for other engines in the chain
+				req.Body.SetBytes(b)
+				slog.DebugContext(req.Context(), "[RewriteEngine.Process] revert request body rewrite")
+			}
+		}()
 		slog.DebugContext(req.Context(), "[RewriteEngine.Run] request body rewritten")
 	}
 	if e.Next == nil {
@@ -145,6 +154,7 @@ func (e *RewriteEngine) Process(req *octollm.Request) (*octollm.Response, error)
 	if err != nil {
 		return nil, fmt.Errorf("underlying engine run error: %w", err)
 	}
+	shouldRevertRewrite = false
 
 	if resp.Stream != nil {
 		if e.StreamChunkRewrite == nil {

--- a/pkg/engines/rewrite_test.go
+++ b/pkg/engines/rewrite_test.go
@@ -133,3 +133,24 @@ func TestRewriteJSON_SetKeyByExpr(t *testing.T) {
 	_, hasStreamOptions := got2["stream_options"]
 	assert.False(t, hasStreamOptions, "stream_options should not be present when expression returns nil")
 }
+
+func TestRewriteEngine_RevertsRequestBodyOnError(t *testing.T) {
+	origin := `{"model": "gpt-4", "key1": "value1"}`
+	req := testhelper.CreateTestRequest(testhelper.WithBody(origin))
+
+	policy := &RewritePolicy{
+		SetKeys: map[string]any{"key1": "rewritten"},
+	}
+
+	errorEngine := &DenyEngine{ReasonText: "upstream error", HTTPStatusCode: 500}
+
+	engine := NewRewriteEngine(errorEngine, policy, nil, nil)
+	_, err := engine.Process(req)
+	require.Error(t, err)
+
+	// body should be reverted to original after the error
+	b, readErr := req.Body.Bytes()
+	require.NoError(t, readErr)
+
+	assert.JSONEq(t, origin, string(b))
+}


### PR DESCRIPTION
Adds a deferred restore so that if the next engine in the chain returns an error, the original (pre-rewrite) request body is put back, preventing downstream engines from seeing a partially rewritten request.