### PR TITLE
feat(openai): support image_url as string or struct in MessageContent…

### DIFF
--- a/pkg/types/openai/chatcompletion_req.go
+++ b/pkg/types/openai/chatcompletion_req.go
@@ -178,16 +178,81 @@ func (m MessageContentArray) MarshalJSON() ([]byte, error) {
 type MessageContentItem struct {
 	Type       string                        `json:"type" binding:"required"`
 	Text       string                        `json:"text,omitempty"`
-	ImageURL   *MessageContentItemImageURL   `json:"image_url,omitempty"`
+	ImageURL   ImageURLContent               `json:"image_url,omitempty"`
 	VideoURL   *MessageContentItemVideoURL   `json:"video_url,omitempty"`
 	AudioURL   *MessageContentItemAudioURL   `json:"audio_url,omitempty"`
 	InputAudio *MessageContentItemInputAudio `json:"input_audio,omitempty"`
 	File       *MessageContentItemFile       `json:"file,omitempty"` // Added for Gemini file support
 }
 
+// UnmarshalJSON 实现 MessageContentItem 的自定义 JSON 反序列化，支持 image_url 为 string 或 struct
+func (m *MessageContentItem) UnmarshalJSON(data []byte) error {
+	type Alias struct {
+		Type       string                        `json:"type"`
+		Text       string                        `json:"text,omitempty"`
+		ImageURL   json.RawMessage               `json:"image_url,omitempty"`
+		VideoURL   *MessageContentItemVideoURL   `json:"video_url,omitempty"`
+		AudioURL   *MessageContentItemAudioURL   `json:"audio_url,omitempty"`
+		InputAudio *MessageContentItemInputAudio `json:"input_audio,omitempty"`
+		File       *MessageContentItemFile       `json:"file,omitempty"`
+	}
+
+	var alias Alias
+	if err := json.Unmarshal(data, &alias); err != nil {
+		return err
+	}
+
+	m.Type = alias.Type
+	m.Text = alias.Text
+	m.VideoURL = alias.VideoURL
+	m.AudioURL = alias.AudioURL
+	m.InputAudio = alias.InputAudio
+	m.File = alias.File
+
+	if len(alias.ImageURL) > 0 {
+		imageURL, err := unmarshalImageURLContent(alias.ImageURL)
+		if err != nil {
+			return err
+		}
+		m.ImageURL = imageURL
+	}
+
+	return nil
+}
+
+// unmarshalImageURLContent 根据 JSON 数据类型解析 ImageURLContent（string 或 struct）
+func unmarshalImageURLContent(data json.RawMessage) (ImageURLContent, error) {
+	var str string
+	if err := json.Unmarshal(data, &str); err == nil {
+		return ImageURLString(str), nil
+	}
+
+	var obj MessageContentItemImageURL
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return nil, err
+	}
+	return &obj, nil
+}
+
 type MessageContentItemImageURL struct {
 	URL    string `json:"url" binding:"required"`
 	Detail string `json:"detail,omitempty"`
+}
+
+func (i *MessageContentItemImageURL) GetImageUrl() string {
+	return i.URL
+}
+
+// ImageURLContent 接口，用于统一获取 image_url（支持 string 或 struct 两种形式）
+type ImageURLContent interface {
+	GetImageUrl() string
+}
+
+// ImageURLString image_url 为 string 类型
+type ImageURLString string
+
+func (i ImageURLString) GetImageUrl() string {
+	return string(i)
 }
 
 type MessageContentItemVideoURL struct {

--- a/pkg/types/openai/chatcompletion_req_test.go
+++ b/pkg/types/openai/chatcompletion_req_test.go
@@ -153,3 +153,173 @@ func TestApiChatCompletionsRequest_UnmarshalJSON(t *testing.T) {
 		t.Errorf("Expected content 'You are a helpful assistant.', got '%s'", content)
 	}
 }
+
+// --- MessageContentItem image_url 支持 string/struct 的测试 ---
+
+func TestMessageContentItem_UnmarshalJSON_ImageURL_String(t *testing.T) {
+	jsonData := `{"type": "image_url", "image_url": "https://example.com/image.png"}`
+	var item MessageContentItem
+	err := json.Unmarshal([]byte(jsonData), &item)
+	if err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if item.Type != "image_url" {
+		t.Errorf("Expected type 'image_url', got '%s'", item.Type)
+	}
+	if item.ImageURL == nil {
+		t.Fatal("Expected ImageURL to be set")
+	}
+	url := item.ImageURL.GetImageUrl()
+	if url != "https://example.com/image.png" {
+		t.Errorf("Expected URL 'https://example.com/image.png', got '%s'", url)
+	}
+	_, ok := item.ImageURL.(ImageURLString)
+	if !ok {
+		t.Errorf("Expected ImageURL to be ImageURLString, got %T", item.ImageURL)
+	}
+}
+
+func TestMessageContentItem_UnmarshalJSON_ImageURL_Struct(t *testing.T) {
+	jsonData := `{"type": "image_url", "image_url": {"url": "https://example.com/img.jpg", "detail": "high"}}`
+	var item MessageContentItem
+	err := json.Unmarshal([]byte(jsonData), &item)
+	if err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if item.Type != "image_url" {
+		t.Errorf("Expected type 'image_url', got '%s'", item.Type)
+	}
+	if item.ImageURL == nil {
+		t.Fatal("Expected ImageURL to be set")
+	}
+	url := item.ImageURL.GetImageUrl()
+	if url != "https://example.com/img.jpg" {
+		t.Errorf("Expected URL 'https://example.com/img.jpg', got '%s'", url)
+	}
+	obj, ok := item.ImageURL.(*MessageContentItemImageURL)
+	if !ok {
+		t.Errorf("Expected ImageURL to be *MessageContentItemImageURL, got %T", item.ImageURL)
+	} else if obj.Detail != "high" {
+		t.Errorf("Expected detail 'high', got '%s'", obj.Detail)
+	}
+}
+
+func TestMessageContentItem_MarshalJSON_ImageURL_String(t *testing.T) {
+	item := MessageContentItem{
+		Type:     "image_url",
+		ImageURL: ImageURLString("https://example.com/pic.png"),
+	}
+	data, err := json.Marshal(item)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("Unmarshal result failed: %v", err)
+	}
+	if m["image_url"] != "https://example.com/pic.png" {
+		t.Errorf("Expected image_url 'https://example.com/pic.png', got '%v'", m["image_url"])
+	}
+}
+
+func TestMessageContentItem_MarshalJSON_ImageURL_Struct(t *testing.T) {
+	item := MessageContentItem{
+		Type: "image_url",
+		ImageURL: &MessageContentItemImageURL{
+			URL:    "https://example.com/photo.jpg",
+			Detail: "low",
+		},
+	}
+	data, err := json.Marshal(item)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("Unmarshal result failed: %v", err)
+	}
+	imgURL, ok := m["image_url"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("Expected image_url to be object, got %T", m["image_url"])
+	}
+	if imgURL["url"] != "https://example.com/photo.jpg" {
+		t.Errorf("Expected url 'https://example.com/photo.jpg', got '%v'", imgURL["url"])
+	}
+	if imgURL["detail"] != "low" {
+		t.Errorf("Expected detail 'low', got '%v'", imgURL["detail"])
+	}
+}
+
+func TestMessageContentItem_ImageURL_RoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		json string
+	}{
+		{"string format", `{"type":"image_url","image_url":"https://a.com/x.png"}`},
+		{"struct format", `{"type":"image_url","image_url":{"url":"https://b.com/y.jpg","detail":"auto"}}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var item MessageContentItem
+			if err := json.Unmarshal([]byte(tt.json), &item); err != nil {
+				t.Fatalf("Unmarshal failed: %v", err)
+			}
+			data, err := json.Marshal(item)
+			if err != nil {
+				t.Fatalf("Marshal failed: %v", err)
+			}
+			var item2 MessageContentItem
+			if err := json.Unmarshal(data, &item2); err != nil {
+				t.Fatalf("Round-trip Unmarshal failed: %v", err)
+			}
+			if item.ImageURL == nil && item2.ImageURL != nil || item.ImageURL != nil && item2.ImageURL == nil {
+				t.Error("ImageURL nil mismatch after round-trip")
+			}
+			if item.ImageURL != nil && item2.ImageURL != nil && item.ImageURL.GetImageUrl() != item2.ImageURL.GetImageUrl() {
+				t.Errorf("URL mismatch: %s vs %s", item.ImageURL.GetImageUrl(), item2.ImageURL.GetImageUrl())
+			}
+		})
+	}
+}
+
+func TestMessage_UnmarshalJSON_Array_WithImageURL(t *testing.T) {
+	jsonData := `{
+		"role": "user",
+		"content": [
+			{"type": "text", "text": "Describe this image"},
+			{"type": "image_url", "image_url": "https://example.com/img.png"}
+		]
+	}`
+	var msg Message
+	err := json.Unmarshal([]byte(jsonData), &msg)
+	if err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	contentArr, ok := msg.Content.(MessageContentArray)
+	if !ok {
+		t.Fatalf("Expected MessageContentArray, got %T", msg.Content)
+	}
+	if len(contentArr) != 2 {
+		t.Fatalf("Expected 2 items, got %d", len(contentArr))
+	}
+	if contentArr[1].Type != "image_url" || contentArr[1].ImageURL == nil {
+		t.Errorf("Expected image_url item with ImageURL set")
+	}
+	if contentArr[1].ImageURL.GetImageUrl() != "https://example.com/img.png" {
+		t.Errorf("Expected URL 'https://example.com/img.png', got '%s'", contentArr[1].ImageURL.GetImageUrl())
+	}
+}
+
+func TestImageURLString_GetImageUrl(t *testing.T) {
+	s := ImageURLString("https://test.com/a.png")
+	if s.GetImageUrl() != "https://test.com/a.png" {
+		t.Errorf("GetImageUrl() = %s, want https://test.com/a.png", s.GetImageUrl())
+	}
+}
+
+func TestMessageContentItemImageURL_GetImageUrl(t *testing.T) {
+	obj := &MessageContentItemImageURL{URL: "https://test.com/b.jpg", Detail: "high"}
+	if obj.GetImageUrl() != "https://test.com/b.jpg" {
+		t.Errorf("GetImageUrl() = %s, want https://test.com/b.jpg", obj.GetImageUrl())
+	}
+}


### PR DESCRIPTION
…Item

- Add ImageURLContent interface and ImageURLString type for flexible image_url
- Implement custom UnmarshalJSON/MarshalJSON for MessageContentItem to handle both string and object formats of image_url (OpenAI API compatibility)
- Add GetImageUrl() to MessageContentItemImageURL for unified URL access
- Add unit tests for image_url string/struct unmarshal, marshal, and round-trip