### PR TITLE
    fix(limiter): improve request limiters TTL and don't update lastRefill when not consuming tokens

### DIFF
--- a/pkg/engines/limiter/request_color_limiter.go
+++ b/pkg/engines/limiter/request_color_limiter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"math"
 	"time"
 
 	"github.com/infinigence/octollm/pkg/errutils"
@@ -18,6 +19,7 @@ type RequestColorLimiterEngine struct {
 	keyPrefix             string        // Redis key prefix for storing token bucket states
 	limits                []int         // Request limits for each supported priority tier (must be strictly decreasing)
 	rates                 []float64     // Token refill rates for each priority tier (calculated from limits and window)
+	ttls                  []int64       // Redis key TTL in seconds per tier; when expired, bucket is guaranteed full
 	window                time.Duration // Time window
 	nameSpace             string        // Namespace for priority context isolation
 	tokenBucketScript     *redis.Script
@@ -81,6 +83,7 @@ func NewRequestColorLimiterEngine(redisClient *redis.Client, keyPrefix string, l
 			keyPrefix:             keyPrefix,
 			limits:                nil,
 			rates:                 nil,
+			ttls:                  nil,
 			window:                0,
 			nameSpace:             nameSpace,
 			tokenBucketScript:     nil,
@@ -99,10 +102,16 @@ func NewRequestColorLimiterEngine(redisClient *redis.Client, keyPrefix string, l
 		return nil, fmt.Errorf("window must be positive")
 	}
 
-	// Calculate rate for each tier: rate = limit / window (in seconds)
+	// Calculate rate and TTL for each tier
 	rates := make([]float64, len(filteredLimits))
+	ttls := make([]int64, len(filteredLimits))
 	for i, limit := range filteredLimits {
 		rates[i] = float64(limit) / window.Seconds()
+		ttlSec := int64(math.Ceil(float64(limit)/rates[i])) + 1
+		if ttlSec < 1 {
+			ttlSec = 1
+		}
+		ttls[i] = ttlSec
 	}
 
 	return &RequestColorLimiterEngine{
@@ -110,6 +119,7 @@ func NewRequestColorLimiterEngine(redisClient *redis.Client, keyPrefix string, l
 		keyPrefix:             keyPrefix,
 		limits:                filteredLimits,
 		rates:                 rates,
+		ttls:                  ttls,
 		window:                window,
 		nameSpace:             nameSpace,
 		tokenBucketScript:     redis.NewScript(tokenBucketLuaScript),
@@ -133,7 +143,6 @@ func (e *RequestColorLimiterEngine) allow(ctx context.Context) (done func(), err
 
 	now := time.Now()
 	nowUnix := now.Unix()
-	windowSeconds := int64(e.window.Seconds())
 
 	// Calculate max supported priority: len(limits) - 1
 	maxSupportedPriority := len(e.limits) - 1
@@ -160,7 +169,7 @@ func (e *RequestColorLimiterEngine) allow(ctx context.Context) (done func(), err
 		rate := e.rates[0]
 
 		result, err := e.tokenBucketScript.Run(ctx, e.redisClient, []string{key},
-			burst, rate, nowUnix, windowSeconds).Result()
+			burst, rate, nowUnix, e.ttls[0]).Result()
 		if err != nil {
 			slog.ErrorContext(ctx, fmt.Sprintf("[RequestColorLimiterEngine] token bucket script error for tier 0: %v, key: %s", err, key))
 			return func() {}, fmt.Errorf("token bucket script error: %w", err)
@@ -196,7 +205,7 @@ func (e *RequestColorLimiterEngine) allow(ctx context.Context) (done func(), err
 
 		// Use atomic dual-key Lua script: check both, consume both or consume neither
 		result, err := e.dualTokenBucketScript.Run(ctx, e.redisClient, []string{ownKey, tier0Key},
-			ownBurst, ownRate, tier0Burst, tier0Rate, nowUnix, windowSeconds, reservedTokens).Result()
+			ownBurst, ownRate, tier0Burst, tier0Rate, nowUnix, e.ttls[tierIdx], e.ttls[0], reservedTokens).Result()
 		if err != nil {
 			slog.ErrorContext(ctx, fmt.Sprintf("[RequestColorLimiterEngine] dual token bucket script error: %v, ownKey: %s, tier0Key: %s", err, ownKey, tier0Key))
 			return func() {}, fmt.Errorf("token bucket script error: %w", err)
@@ -279,8 +288,9 @@ func (e *RequestColorLimiterEngine) getPriorityFromContext(ctx context.Context) 
 // ARGV[3]: tier0Burst (maximum tokens for tier 0)
 // ARGV[4]: tier0Rate (refill rate for tier 0)
 // ARGV[5]: nowUnix (current timestamp)
-// ARGV[6]: windowSeconds (time window in seconds)
-// ARGV[7]: reservedTokens (tokens to reserve in tier 0 for higher priority)
+// ARGV[6]: ownTtl (Redis key TTL in seconds for own tier)
+// ARGV[7]: tier0Ttl (Redis key TTL in seconds for tier 0)
+// ARGV[8]: reservedTokens (tokens to reserve in tier 0 for higher priority)
 // Returns: {allowed, ownTokens, tier0Tokens}
 const dualTokenBucketLuaScript = `
 local ownKey = KEYS[1]
@@ -290,8 +300,9 @@ local ownRate = tonumber(ARGV[2])
 local tier0Burst = tonumber(ARGV[3])
 local tier0Rate = tonumber(ARGV[4])
 local nowUnix = tonumber(ARGV[5])
-local windowSeconds = tonumber(ARGV[6])
-local reservedTokens = tonumber(ARGV[7])
+local ownTtl = tonumber(ARGV[6])
+local tier0Ttl = tonumber(ARGV[7])
+local reservedTokens = tonumber(ARGV[8])
 
 -- Get own tier bucket state
 local ownBucket = redis.call('HMGET', ownKey, 'tokens', 'lastRefill')
@@ -323,15 +334,9 @@ if ownTokens >= 1 and tier0Tokens > reservedTokens then
     
     -- Update both buckets
     redis.call('HMSET', ownKey, 'tokens', ownTokens, 'lastRefill', nowUnix)
-    redis.call('EXPIRE', ownKey, windowSeconds * 2)
     redis.call('HMSET', tier0Key, 'tokens', tier0Tokens, 'lastRefill', nowUnix)
-    redis.call('EXPIRE', tier0Key, windowSeconds * 2)
-else
-    -- Conditions not met, only update refill times without consuming
-    redis.call('HMSET', ownKey, 'tokens', ownTokens, 'lastRefill', nowUnix)
-    redis.call('EXPIRE', ownKey, windowSeconds * 2)
-    redis.call('HMSET', tier0Key, 'tokens', tier0Tokens, 'lastRefill', nowUnix)
-    redis.call('EXPIRE', tier0Key, windowSeconds * 2)
+	redis.call('EXPIRE', ownKey, ownTtl)
+    redis.call('EXPIRE', tier0Key, tier0Ttl)
 end
 
 return {allowed, ownTokens, tier0Tokens}

--- a/pkg/engines/limiter/request_color_limiter_test.go
+++ b/pkg/engines/limiter/request_color_limiter_test.go
@@ -1,0 +1,186 @@
+package limiter
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	miniredis "github.com/alicebob/miniredis/v2"
+	"github.com/infinigence/octollm/pkg/errutils"
+	"github.com/infinigence/octollm/pkg/octollm"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+)
+
+func newRequestColorLimiterTestRequest(t *testing.T, nameSpace string, priority int) *octollm.Request {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://example.com", strings.NewReader("body"))
+	assert.NoError(t, err)
+	r := octollm.NewRequest(req, octollm.APIFormatUnknown)
+	ctx := context.WithValue(r.Context(), contextKey(fmt.Sprintf("%s:%s", nameSpace, ContextKeyPriority)),
+		fmt.Sprintf("%s%d", ContextValuePrefixPriority, priority))
+	return r.WithContext(ctx)
+}
+
+func TestNewRequestColorLimiterEngine_Validation(t *testing.T) {
+	next := &nextStubEngine{}
+
+	// next must not be nil
+	_, err := NewRequestColorLimiterEngine(nil, "k", []int{100}, time.Minute, "ns", nil)
+	assert.Error(t, err)
+
+	// empty limits -> disabled (pass-through)
+	e, err := NewRequestColorLimiterEngine(nil, "k", nil, time.Minute, "ns", next)
+	assert.NoError(t, err)
+	assert.Nil(t, e.limits)
+	assert.Nil(t, e.ttls)
+
+	// window must be positive
+	_, err = NewRequestColorLimiterEngine(nil, "k", []int{100}, 0, "ns", next)
+	assert.Error(t, err)
+
+	// valid config
+	e, err = NewRequestColorLimiterEngine(nil, "k", []int{200, 100, 50}, time.Minute, "ns", next)
+	assert.NoError(t, err)
+	assert.Len(t, e.limits, 3)
+	assert.Len(t, e.ttls, 3)
+}
+
+func TestRequestColorLimiter_PassThroughWhenDisabled(t *testing.T) {
+	next := &nextStubEngine{}
+
+	e, err := NewRequestColorLimiterEngine(nil, "k", nil, time.Minute, "ns", next)
+	assert.NoError(t, err)
+
+	req := newRequestColorLimiterTestRequest(t, "ns", 0)
+	resp, err := e.Process(req)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, 1, next.callCount)
+}
+
+func TestRequestColorLimiter_PriorityInContext(t *testing.T) {
+	mr := miniredis.RunT(t)
+	defer mr.Close()
+
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	next := &nextStubEngine{}
+	ns := "limiter-ns"
+
+	// limits=[5, 3, 2]: tier 0=5, tier 1=3, tier 2=2. All share tier 0.
+	// Use separate keyPrefix per test to isolate (tier 0 is shared within same keyPrefix)
+	e, err := NewRequestColorLimiterEngine(client, "limiter-p2", []int{5, 3, 2}, time.Minute, ns, next)
+	assert.NoError(t, err)
+
+	// Priority 2 (tier 0 only): 5 requests allowed
+	for i := 0; i < 5; i++ {
+		req := newRequestColorLimiterTestRequest(t, ns, 2)
+		resp, err := e.Process(req)
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+	}
+	assert.Equal(t, 5, next.callCount)
+
+	// 6th with priority 2 -> rejected
+	req := newRequestColorLimiterTestRequest(t, ns, 2)
+	_, err = e.Process(req)
+	assert.Error(t, err)
+	var upErr *errutils.UpstreamRespError
+	assert.ErrorAs(t, err, &upErr)
+	assert.Equal(t, 429, upErr.StatusCode)
+	assert.Equal(t, 5, next.callCount)
+
+	// Priority 1: use fresh engine/keyPrefix so tier 0 has tokens
+	e1, _ := NewRequestColorLimiterEngine(client, "limiter-p1", []int{5, 3, 2}, time.Minute, ns, next)
+	for i := 0; i < 3; i++ {
+		req := newRequestColorLimiterTestRequest(t, ns, 1)
+		resp, err := e1.Process(req)
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+	}
+	assert.Equal(t, 8, next.callCount)
+
+	req = newRequestColorLimiterTestRequest(t, ns, 1)
+	_, err = e1.Process(req)
+	assert.Error(t, err)
+	assert.Equal(t, 8, next.callCount)
+
+	// Priority 0: use fresh engine/keyPrefix
+	e0, _ := NewRequestColorLimiterEngine(client, "limiter-p0", []int{5, 3, 2}, time.Minute, ns, next)
+	for i := 0; i < 2; i++ {
+		req := newRequestColorLimiterTestRequest(t, ns, 0)
+		resp, err := e0.Process(req)
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+	}
+	assert.Equal(t, 10, next.callCount)
+
+	req = newRequestColorLimiterTestRequest(t, ns, 0)
+	_, err = e0.Process(req)
+	assert.Error(t, err)
+	assert.Equal(t, 10, next.callCount)
+}
+
+func TestRequestColorLimiter_MarkerChain(t *testing.T) {
+	mr := miniredis.RunT(t)
+	defer mr.Close()
+
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	next := &nextStubEngine{}
+	ns := "chain-ns"
+
+	// Marker: limits=[2, 5, 10]. Limiter: limits=[10, 5, 2], shared tier 0.
+	// 8 pass: 2 p2 + 3 p1 + 2 p0 (limiter tier0 and tier2 constrain p0 to 2)
+	limiter, err := NewRequestColorLimiterEngine(client, "chain-limiter", []int{10, 5, 2}, time.Minute, ns, next)
+	assert.NoError(t, err)
+
+	marker, err := NewRequestColorMarkerEngine(client, "chain-marker", []int{2, 5, 10}, time.Minute, ns, limiter)
+	assert.NoError(t, err)
+
+	// Expect 8 through: 2 p2 + 3 p1 + 2 p0 (limiter tier0 and tier2 constrain p0 to 2)
+	for i := 0; i < 8; i++ {
+		req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://example.com", strings.NewReader("body"))
+		r := octollm.NewRequest(req, octollm.APIFormatUnknown)
+		resp, err := marker.Process(r)
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+	}
+	assert.Equal(t, 8, next.callCount)
+
+	// 9th: marker may allow (tier 2 has 3 left) but limiter rejects; or marker rejects
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://example.com", strings.NewReader("body"))
+	r := octollm.NewRequest(req, octollm.APIFormatUnknown)
+	_, err = marker.Process(r)
+	assert.Error(t, err)
+	assert.Equal(t, 8, next.callCount)
+}
+
+func TestRequestColorLimiter_NoPriorityDefaultsToLowest(t *testing.T) {
+	mr := miniredis.RunT(t)
+	defer mr.Close()
+
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	next := &nextStubEngine{}
+
+	e, err := NewRequestColorLimiterEngine(client, "limiter-noprio", []int{10, 2}, time.Minute, "ns", next)
+	assert.NoError(t, err)
+
+	// Request without priority in context -> defaults to priority 0 (lowest tier, 2 requests)
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://example.com", strings.NewReader("body"))
+	r := octollm.NewRequest(req, octollm.APIFormatUnknown)
+
+	for i := 0; i < 2; i++ {
+		resp, err := e.Process(r)
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+	}
+	assert.Equal(t, 2, next.callCount)
+
+	// 3rd rejected
+	_, err = e.Process(r)
+	assert.Error(t, err)
+	assert.Equal(t, 2, next.callCount)
+}

--- a/pkg/engines/limiter/request_color_marker.go
+++ b/pkg/engines/limiter/request_color_marker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"math"
 	"time"
 
 	"github.com/infinigence/octollm/pkg/errutils"
@@ -18,6 +19,7 @@ type RequestColorMarkerEngine struct {
 	keyPrefix         string        // Redis key prefix for storing token bucket states
 	limits            []int         // Request limits for each priority tier (must be strictly increasing)
 	rates             []float64     // Token refill rates for each priority tier (calculated from limits and window)
+	ttls              []int64       // Redis key TTL in seconds per tier; when expired, bucket is guaranteed full
 	window            time.Duration // Time window
 	nameSpace         string        // Namespace for priority context isolation
 	tokenBucketScript *redis.Script
@@ -71,6 +73,7 @@ func NewRequestColorMarkerEngine(redisClient *redis.Client, keyPrefix string, li
 			keyPrefix:         keyPrefix,
 			limits:            nil,
 			rates:             nil,
+			ttls:              nil,
 			window:            0,
 			nameSpace:         nameSpace,
 			tokenBucketScript: nil,
@@ -88,10 +91,16 @@ func NewRequestColorMarkerEngine(redisClient *redis.Client, keyPrefix string, li
 		return nil, fmt.Errorf("window must be positive")
 	}
 
-	// Calculate rate for each tier: rate = limit / window (in seconds)
+	// Calculate rate and TTL for each tier
 	rates := make([]float64, len(filteredLimits))
+	ttls := make([]int64, len(filteredLimits))
 	for i, limit := range filteredLimits {
 		rates[i] = float64(limit) / window.Seconds()
+		ttlSec := int64(math.Ceil(float64(limit)/rates[i])) + 1
+		if ttlSec < 1 {
+			ttlSec = 1
+		}
+		ttls[i] = ttlSec
 	}
 
 	return &RequestColorMarkerEngine{
@@ -99,6 +108,7 @@ func NewRequestColorMarkerEngine(redisClient *redis.Client, keyPrefix string, li
 		keyPrefix:         keyPrefix,
 		limits:            filteredLimits,
 		rates:             rates,
+		ttls:              ttls,
 		window:            window,
 		nameSpace:         nameSpace,
 		tokenBucketScript: redis.NewScript(tokenBucketColorMarkerAquireLuaScript),
@@ -116,7 +126,6 @@ func (e *RequestColorMarkerEngine) allow(ctx context.Context) (newCtx context.Co
 
 	now := time.Now()
 	nowUnix := now.Unix()
-	windowSeconds := int64(e.window.Seconds())
 
 	// Build all tier keys
 	numTiers := len(e.limits)
@@ -125,13 +134,16 @@ func (e *RequestColorMarkerEngine) allow(ctx context.Context) (newCtx context.Co
 		keys[i] = fmt.Sprintf("%s:tier_%d", e.keyPrefix, i)
 	}
 
-	// Build ARGV: numTiers, burst1, rate1, burst2, rate2, ..., nowUnix, windowSeconds
-	args := make([]interface{}, 0, 1+numTiers*2+2)
+	// Build ARGV: numTiers, burst1, rate1, burst2, rate2, ..., nowUnix, ttl1, ttl2, ...
+	args := make([]interface{}, 0, 1+numTiers*2+1+numTiers)
 	args = append(args, numTiers)
 	for i := 0; i < numTiers; i++ {
 		args = append(args, e.limits[i], e.rates[i])
 	}
-	args = append(args, nowUnix, windowSeconds)
+	args = append(args, nowUnix)
+	for i := 0; i < numTiers; i++ {
+		args = append(args, e.ttls[i])
+	}
 
 	// Call Lua script
 	result, err := e.tokenBucketScript.Run(ctx, e.redisClient, keys, args...).Result()
@@ -208,7 +220,7 @@ func (e *RequestColorMarkerEngine) setPriorityToContext(ctx context.Context, pri
 // ARGV[1]: numTiers
 // ARGV[2..2*numTiers+1]: burst1, rate1, burst2, rate2, ...
 // ARGV[2*numTiers+2]: nowUnix
-// ARGV[2*numTiers+3]: windowSeconds
+// ARGV[2*numTiers+3..2*numTiers+2+numTiers]: ttl1, ttl2, ...
 //
 // Returns: {priority, acquiredKeysIndices}
 // - priority: 0 means rejected, >0 means acquired with priority (1-based, convert to 0-based in Go)
@@ -217,12 +229,15 @@ const tokenBucketColorMarkerAquireLuaScript = `
 local numTiers = tonumber(ARGV[1])
 local bursts = {}
 local rates = {}
+local ttls = {}
 for i = 1, numTiers do
     bursts[i] = tonumber(ARGV[1 + (i-1)*2 + 1])
     rates[i] = tonumber(ARGV[1 + (i-1)*2 + 2])
 end
 local nowUnix = tonumber(ARGV[2*numTiers + 2])
-local windowSeconds = tonumber(ARGV[2*numTiers + 3])
+for i = 1, numTiers do
+    ttls[i] = tonumber(ARGV[2*numTiers + 2 + i])
+end
 
 local lastTierIdx = numTiers
 
@@ -242,7 +257,7 @@ end
 -- Helper function to update bucket
 local function updateBucket(keyIdx, tokens)
     redis.call('HMSET', KEYS[keyIdx], 'tokens', tokens, 'lastRefill', nowUnix)
-    redis.call('EXPIRE', KEYS[keyIdx], windowSeconds * 2)
+    redis.call('EXPIRE', KEYS[keyIdx], ttls[keyIdx])
 end
 
 -- Phase 1: Find first available tier from tier 0 (highest priority) to last tier
@@ -259,11 +274,8 @@ for tierIdx = 1, numTiers do
     end
 end
 
--- If no tier is available, update all buckets and reject
+-- If no tier is available, reject without updating (don't update lastRefill when not consuming)
 if foundTierIdx == nil then
-    for tierIdx = 1, numTiers do
-        updateBucket(tierIdx, tiersTokens[tierIdx])
-    end
     return {0, ""}
 end
 
@@ -287,37 +299,16 @@ else
         keysToConsume[1] = {keyIdx = foundTierIdx, tokens = tiersTokens[foundTierIdx]}
         keysToConsume[2] = {keyIdx = lastTierIdx, tokens = lastTierTokens}
     else
-        -- Last tier not available: update all checked buckets and reject
-        for tierIdx = 1, numTiers do
-            if tiersTokens[tierIdx] ~= nil then
-                updateBucket(tierIdx, tiersTokens[tierIdx])
-            end
-        end
+        -- Last tier not available: reject without updating (don't update lastRefill when not consuming)
         return {0, ""}
     end
 end
 
--- Phase 3: Consume tokens from required buckets
+-- Phase 3: Consume tokens from required buckets (only update lastRefill when consuming)
 for i = 1, #keysToConsume do
     local keyIdx = keysToConsume[i].keyIdx
     local tokens = keysToConsume[i].tokens - 1
     updateBucket(keyIdx, tokens)
-end
-
--- Update buckets that were checked but not consumed
-for tierIdx = 1, numTiers do
-    if tiersTokens[tierIdx] ~= nil then
-        local isConsumed = false
-        for i = 1, #keysToConsume do
-            if keysToConsume[i].keyIdx == tierIdx then
-                isConsumed = true
-                break
-            end
-        end
-        if not isConsumed then
-            updateBucket(tierIdx, tiersTokens[tierIdx])
-        end
-    end
 end
 
 -- Build acquired keys indices string

--- a/pkg/engines/limiter/request_color_marker_test.go
+++ b/pkg/engines/limiter/request_color_marker_test.go
@@ -1,0 +1,144 @@
+package limiter
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	miniredis "github.com/alicebob/miniredis/v2"
+	"github.com/infinigence/octollm/pkg/errutils"
+	"github.com/infinigence/octollm/pkg/octollm"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+)
+
+func newRequestColorMarkerTestRequest(t *testing.T) *octollm.Request {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://example.com", strings.NewReader("body"))
+	assert.NoError(t, err)
+	return octollm.NewRequest(req, octollm.APIFormatUnknown)
+}
+
+func TestNewRequestColorMarkerEngine_Validation(t *testing.T) {
+	next := &nextStubEngine{}
+
+	// next must not be nil
+	_, err := NewRequestColorMarkerEngine(nil, "k", []int{10}, time.Minute, "ns", nil)
+	assert.Error(t, err)
+
+	// empty limits -> disabled (pass-through)
+	e, err := NewRequestColorMarkerEngine(nil, "k", nil, time.Minute, "ns", next)
+	assert.NoError(t, err)
+	assert.Nil(t, e.limits)
+	assert.Nil(t, e.ttls)
+
+	// window must be positive
+	_, err = NewRequestColorMarkerEngine(nil, "k", []int{10}, 0, "ns", next)
+	assert.Error(t, err)
+
+	// valid config
+	e, err = NewRequestColorMarkerEngine(nil, "k", []int{10, 50, 100}, time.Minute, "ns", next)
+	assert.NoError(t, err)
+	assert.Len(t, e.limits, 3)
+	assert.Len(t, e.ttls, 3)
+}
+
+func TestRequestColorMarker_PassThroughWhenDisabled(t *testing.T) {
+	next := &nextStubEngine{}
+
+	e, err := NewRequestColorMarkerEngine(nil, "k", nil, time.Minute, "ns", next)
+	assert.NoError(t, err)
+
+	req := newRequestColorMarkerTestRequest(t)
+	resp, err := e.Process(req)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, 1, next.callCount)
+}
+
+func TestRequestColorMarker_MultiTier_AcquirePriority(t *testing.T) {
+	mr := miniredis.RunT(t)
+	defer mr.Close()
+
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	next := &nextStubEngine{}
+
+	// limits=[2, 5, 10]: tier 0 allows 2, tier 1 allows 5, tier 2 allows 10
+	// tier 0 + tier 2 consumed together when from tier 0; tier 1 + tier 2 when from tier 1; tier 2 only when from tier 2
+	e, err := NewRequestColorMarkerEngine(client, "marker-test", []int{2, 5, 10}, time.Minute, "ns", next)
+	assert.NoError(t, err)
+
+	// First 2 requests: acquire from tier 0 -> priority 2
+	for i := 0; i < 2; i++ {
+		req := newRequestColorMarkerTestRequest(t)
+		resp, err := e.Process(req)
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+	}
+	assert.Equal(t, 2, next.callCount)
+
+	// Next 3 requests: tier 0 exhausted, acquire from tier 1 -> priority 1
+	for i := 0; i < 3; i++ {
+		req := newRequestColorMarkerTestRequest(t)
+		resp, err := e.Process(req)
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+	}
+	assert.Equal(t, 5, next.callCount)
+
+	// Next 5 requests: tier 1 exhausted, acquire from tier 2 only -> priority 0
+	for i := 0; i < 5; i++ {
+		req := newRequestColorMarkerTestRequest(t)
+		resp, err := e.Process(req)
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+	}
+	assert.Equal(t, 10, next.callCount)
+
+	// 11th request: all tiers exhausted -> rejected
+	req := newRequestColorMarkerTestRequest(t)
+	resp, err := e.Process(req)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	var upErr *errutils.UpstreamRespError
+	assert.ErrorAs(t, err, &upErr)
+	assert.Equal(t, 429, upErr.StatusCode)
+	assert.Equal(t, 10, next.callCount)
+}
+
+func TestRequestColorMarker_RefillOverTime(t *testing.T) {
+	mr := miniredis.RunT(t)
+	defer mr.Close()
+
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	next := &nextStubEngine{}
+
+	// limits=[2, 4], window=30s: tier 0 rate=2/30, refill 1 token in 15s
+	e, err := NewRequestColorMarkerEngine(client, "marker-refill", []int{2, 4}, 30*time.Second, "ns", next)
+	assert.NoError(t, err)
+
+	// Exhaust all 4 (2 from tier 0+tier1, 2 from tier 1+tier1)
+	for i := 0; i < 4; i++ {
+		req := newRequestColorMarkerTestRequest(t)
+		_, err := e.Process(req)
+		assert.NoError(t, err)
+	}
+	assert.Equal(t, 4, next.callCount)
+
+	// 5th rejected
+	req := newRequestColorMarkerTestRequest(t)
+	_, err = e.Process(req)
+	assert.Error(t, err)
+	assert.Equal(t, 4, next.callCount)
+
+	// Wait for refill (~16s for 1 token in tier 0)
+	time.Sleep(18 * time.Second)
+
+	req = newRequestColorMarkerTestRequest(t)
+	resp, err := e.Process(req)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, 5, next.callCount)
+}

--- a/pkg/engines/limiter/request_limiter.go
+++ b/pkg/engines/limiter/request_limiter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"math"
 	"time"
 
 	"github.com/infinigence/octollm/pkg/errutils"
@@ -18,6 +19,7 @@ type RequestLimiterEngine struct {
 	burst             int           // Maximum number of tokens
 	rate              float64       // Number of tokens added per second
 	window            time.Duration // Time window
+	ttlSec            int64         // Redis key TTL in seconds; when expired, bucket is guaranteed full
 	tokenBucketScript *redis.Script
 	next              octollm.Engine
 }
@@ -49,6 +51,7 @@ func NewRequestLimiterEngine(redisClient *redis.Client, key string, burst int, l
 			burst:             0,
 			rate:              0,
 			window:            0,
+			ttlSec:            0,
 			tokenBucketScript: nil,
 			next:              next,
 		}, nil
@@ -62,12 +65,19 @@ func NewRequestLimiterEngine(redisClient *redis.Client, key string, burst int, l
 	// This ensures that within the time window, at most 'limit' requests can pass through
 	rate := float64(limit) / window.Seconds()
 
+	// TTL = time to refill from 0 to burst + 1s buffer; when expired, bucket is guaranteed full
+	ttlSec := int64(math.Ceil(float64(burst)/rate)) + 1
+	if ttlSec < 1 {
+		ttlSec = 1
+	}
+
 	return &RequestLimiterEngine{
 		redisClient:       redisClient,
 		key:               key,
 		burst:             burst,
 		rate:              rate,
 		window:            window,
+		ttlSec:            ttlSec,
 		tokenBucketScript: redis.NewScript(tokenBucketLuaScript),
 		next:              next,
 	}, nil
@@ -82,11 +92,10 @@ func (e *RequestLimiterEngine) allow(ctx context.Context) (done func(), err erro
 
 	now := time.Now()
 	nowUnix := now.Unix()
-	windowSeconds := int64(e.window.Seconds())
 
 	// Use Lua script to implement token bucket algorithm
 	result, err := e.tokenBucketScript.Run(ctx, e.redisClient, []string{e.key},
-		e.burst, e.rate, nowUnix, windowSeconds).Result()
+		e.burst, e.rate, nowUnix, e.ttlSec).Result()
 	if err != nil {
 		slog.ErrorContext(ctx, fmt.Sprintf("[RequestLimiterEngine] token bucket script error: %v, key: %s", err, e.key))
 		return func() {}, fmt.Errorf("token bucket script error: %w", err)
@@ -148,13 +157,13 @@ func (e *RequestLimiterEngine) Process(req *octollm.Request) (*octollm.Response,
 // ARGV[1]: burst (maximum number of tokens)
 // ARGV[2]: rate (number of tokens added per second)
 // ARGV[3]: nowUnix (current timestamp)
-// ARGV[4]: windowSeconds (time window in seconds)
+// ARGV[4]: ttlSec (Redis key TTL in seconds; when expired, bucket is guaranteed full)
 const tokenBucketLuaScript = `
 local key = KEYS[1]
 local burst = tonumber(ARGV[1])
 local rate = tonumber(ARGV[2])
 local nowUnix = tonumber(ARGV[3])
-local windowSeconds = tonumber(ARGV[4])
+local ttlSec = tonumber(ARGV[4])
 
 -- Get current token bucket state
 local bucket = redis.call('HMGET', key, 'tokens', 'lastRefill')
@@ -173,11 +182,10 @@ local allowed = 0
 if tokens >= 1 then
     tokens = tokens - 1
     allowed = 1
+	redis.call('HMSET', key, 'tokens', tokens, 'lastRefill', nowUnix)
+	redis.call('EXPIRE', key, ttlSec)
 end
 
--- Update token bucket state
-redis.call('HMSET', key, 'tokens', tokens, 'lastRefill', nowUnix)
-redis.call('EXPIRE', key, windowSeconds * 2)
 
 return {allowed, tokens}
 `

--- a/pkg/engines/limiter/request_limiter_test.go
+++ b/pkg/engines/limiter/request_limiter_test.go
@@ -1,0 +1,70 @@
+package limiter
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	miniredis "github.com/alicebob/miniredis/v2"
+	"github.com/infinigence/octollm/pkg/errutils"
+	"github.com/infinigence/octollm/pkg/octollm"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+)
+
+func newRequestLimiterTestRequest(t *testing.T) *octollm.Request {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://example.com", strings.NewReader("body"))
+	assert.NoError(t, err)
+	return octollm.NewRequest(req, octollm.APIFormatUnknown)
+}
+
+// TestRequestLimiter_2PerMinute_1PerSecond_35Seconds tests: 2 requests per minute, 1 request per second, for 35 seconds.
+// Expected: first 2 pass, ~28 rejected in between, 3rd passes around second 31 (token refills in ~30s).
+func TestRequestLimiter_2PerMinute_1PerSecond_35Seconds(t *testing.T) {
+	mr := miniredis.RunT(t)
+	defer mr.Close()
+
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	next := &nextStubEngine{
+		resp: &octollm.Response{StatusCode: 200},
+	}
+
+	// 1分钟2个请求: burst=2, limit=2, window=1min, rate=2/60≈0.0333 tokens/sec
+	e, err := NewRequestLimiterEngine(client, "req-bucket", 2, 2, time.Minute, next)
+	assert.NoError(t, err)
+
+	allowedCount := 0
+	deniedCount := 0
+
+	for i := 0; i < 35; i++ {
+		req := newRequestLimiterTestRequest(t)
+		resp, err := e.Process(req)
+
+		allowed := err == nil && resp != nil
+		if allowed {
+			allowedCount++
+			t.Logf("[sec %2d] request #%2d: allowed (next.callCount=%d)", i, i+1, next.callCount)
+		} else {
+			deniedCount++
+			var upErr *errutils.UpstreamRespError
+			statusCode := 0
+			if assert.ErrorAs(t, err, &upErr) {
+				statusCode = upErr.StatusCode
+			}
+			t.Logf("[sec %2d] request #%2d: rate limited (status=%d, err=%v)", i, i+1, statusCode, err)
+		}
+
+		// 1 request per second
+		if i < 34 {
+			time.Sleep(time.Second)
+		}
+	}
+
+	t.Logf("--- summary: allowed=%d, denied=%d, next.callCount=%d ---", allowedCount, deniedCount, next.callCount)
+
+	assert.Equal(t, 3, allowedCount, "expected 3 requests to pass")
+	assert.Equal(t, 3, next.callCount, "next engine should be called 3 times")
+}


### PR DESCRIPTION
 - Compute Redis key TTL from burst/rate (ceil(burst/rate)+1) instead of fixed 2*window
      so keys expire only when bucket is guaranteed full
    - Precompute TTL in New() and pass to Lua scripts instead of calculating per request
    - Don't update lastRefill when not consuming tokens; fixes continuous rejected
      requests preventing natural token refill (request_color_limiter, request_color_marker)
    - Add unit tests for RequestColorMarkerEngine and RequestColorLimiterEngine
