### PR TITLE
fix(limiter): defer concurrency release until stream/body is fully consumed

### DIFF
--- a/pkg/engines/limiter/concurrency_color_limiter.go
+++ b/pkg/engines/limiter/concurrency_color_limiter.go
@@ -243,7 +243,13 @@ func (e *ConcurrencyColorLimiterEngine) Process(req *octollm.Request) (*octollm.
 	resp, err := e.next.Process(req)
 
 	// Call done to cleanup regardless of success or failure
-	done()
+	if resp.Stream != nil {
+		resp.Stream.OnClose(done)
+	} else if resp.Body != nil {
+		resp.Body.OnClose(done)
+	} else {
+		done()
+	}
 
 	return resp, err
 }

--- a/pkg/engines/limiter/concurrency_color_marker.go
+++ b/pkg/engines/limiter/concurrency_color_marker.go
@@ -197,7 +197,13 @@ func (e *ConcurrencyColorMarkerEngine) Process(req *octollm.Request) (*octollm.R
 	resp, err := e.next.Process(req)
 
 	// Call done to cleanup regardless of success or failure
-	done()
+	if resp.Stream != nil {
+		resp.Stream.OnClose(done)
+	} else if resp.Body != nil {
+		resp.Body.OnClose(done)
+	} else {
+		done()
+	}
 
 	return resp, err
 }

--- a/pkg/engines/limiter/concurrency_limiter.go
+++ b/pkg/engines/limiter/concurrency_limiter.go
@@ -143,7 +143,13 @@ func (e *ConcurrencyLimiterEngine) Process(req *octollm.Request) (*octollm.Respo
 	resp, err := e.next.Process(req)
 
 	// Call done to cleanup regardless of success or failure
-	done()
+	if resp.Stream != nil {
+		resp.Stream.OnClose(done)
+	} else if resp.Body != nil {
+		resp.Body.OnClose(done)
+	} else {
+		done()
+	}
 
 	return resp, err
 }

--- a/pkg/octollm/request.go
+++ b/pkg/octollm/request.go
@@ -39,6 +39,8 @@ type UnifiedBody struct {
 	parser   Parser // parser (must be set before use)
 	parseErr error  // parsing error
 	isDirty  bool   // marks if parsed data is manually modified
+
+	closeFunc func()
 }
 
 func NewBodyFromReader(reader io.ReadCloser, parser Parser) *UnifiedBody {
@@ -166,10 +168,25 @@ func (b *UnifiedBody) SetParsed(v any) {
 }
 
 func (b *UnifiedBody) Close() error {
+	if b.closeFunc != nil {
+		b.closeFunc()
+	}
 	if b.reader == nil {
 		return nil
 	}
 	return b.reader.Close()
+}
+
+func (b *UnifiedBody) OnClose(closeFunc func()) {
+	if b.closeFunc == nil {
+		b.closeFunc = closeFunc
+	} else {
+		prevClose := b.closeFunc
+		b.closeFunc = func() {
+			prevClose()
+			closeFunc()
+		}
+	}
 }
 
 type Request struct {
@@ -235,6 +252,18 @@ func (sc *StreamChan) Chan() <-chan *StreamChunk {
 func (sc *StreamChan) Close() {
 	if sc.closeFunc != nil {
 		sc.closeFunc()
+	}
+}
+
+func (sc *StreamChan) OnClose(closeFunc func()) {
+	if sc.closeFunc == nil {
+		sc.closeFunc = closeFunc
+	} else {
+		prevClose := sc.closeFunc
+		sc.closeFunc = func() {
+			prevClose()
+			closeFunc()
+		}
 	}
 }
 


### PR DESCRIPTION
For streaming responses, call done() via OnClose hook instead of immediately after Process() returns, ensuring the concurrency slot is held until the client finishes reading the stream.