### PR TITLE
chore: comment out per-chunk debug logs in http endpoint and moderator

### DIFF
--- a/pkg/engines/client/http.go
+++ b/pkg/engines/client/http.go
@@ -229,7 +229,7 @@ func (e *HTTPEndpoint) processSSEStream(ctx context.Context, req *octollm.Reques
 				continue
 			}
 			body := octollm.NewBodyFromBytes(bodyBuffer, streamParser)
-			bodyLen := len(bodyBuffer)
+			// bodyLen := len(bodyBuffer)
 			bodyBuffer = make([]byte, 0, 512)
 			chunk := &octollm.StreamChunk{Body: body}
 			if len(metaBuffer) > 0 {
@@ -238,7 +238,7 @@ func (e *HTTPEndpoint) processSSEStream(ctx context.Context, req *octollm.Reques
 			}
 			select {
 			case ch <- chunk:
-				slog.DebugContext(ctx, fmt.Sprintf("[http-endpoint] pushed stream chunk: len=%d", bodyLen))
+				// slog.DebugContext(ctx, fmt.Sprintf("[http-endpoint] pushed stream chunk: len=%d", bodyLen))
 			case <-ctx.Done():
 				slog.InfoContext(ctx, fmt.Sprintf("[http-endpoint] context error during stream response: %v", ctx.Err()))
 				return
@@ -328,7 +328,7 @@ func (e *HTTPEndpoint) processJSONStream(ctx context.Context, req *octollm.Reque
 
 		select {
 		case ch <- chunk:
-			slog.DebugContext(ctx, fmt.Sprintf("[http-endpoint] pushed JSON stream chunk: len=%d", len(rawMsg)))
+			// slog.DebugContext(ctx, fmt.Sprintf("[http-endpoint] pushed JSON stream chunk: len=%d", len(rawMsg)))
 		case <-ctx.Done():
 			slog.InfoContext(ctx, fmt.Sprintf("[http-endpoint] context error during JSON stream response: %v", ctx.Err()))
 			return

--- a/pkg/engines/moderator/moderator.go
+++ b/pkg/engines/moderator/moderator.go
@@ -125,7 +125,7 @@ func (e *TextModeratorEngine) Process(req *octollm.Request) (*octollm.Response, 
 
 		slog.DebugContext(ctx, fmt.Sprintf("[moderate] begin reading upstream stream"))
 		for chunk := range originalChunks.Chan() {
-			slog.DebugContext(ctx, fmt.Sprintf("[moderate] stream chunk"))
+			// slog.DebugContext(ctx, fmt.Sprintf("[moderate] stream chunk"))
 			text, err := e.TextModeratorAdapter.ExtractTextFromBody(ctx, chunk.Body)
 			if err != nil {
 				// stream done 是正常结束信号，不应该视为错误
@@ -138,7 +138,7 @@ func (e *TextModeratorEngine) Process(req *octollm.Request) (*octollm.Response, 
 				moderationFailedErr = fmt.Errorf("%w: %w", ErrModeratorInternalError, err)
 				break
 			}
-			slog.DebugContext(ctx, fmt.Sprintf("[moderate] extract text from stream chunk: %s", string(text)))
+			// slog.DebugContext(ctx, fmt.Sprintf("[moderate] extract text from stream chunk: %s", string(text)))
 			textBuffer = append(textBuffer, text...)
 			if len(textBuffer) > maxRuneLen {
 				// truncate text to last max rune len


### PR DESCRIPTION
Remove the highest-frequency log prints that fired on every single stream chunk, which would flood logs under normal production traffic.