### PR TITLE
fix(log): add is_duplicate_request context field && fix panic in replicated request

### DIFF
--- a/cmd/octollm-server/context_fields_handler.go
+++ b/cmd/octollm-server/context_fields_handler.go
@@ -31,6 +31,10 @@ func (h *contextFieldsHandler) Handle(ctx context.Context, r slog.Record) error 
 				slog.String("span_id", sc.SpanID().String()),
 			)
 		}
+
+		if v, _ := ctx.Value("is_duplicate_request").(bool); v {
+			r.AddAttrs(slog.Bool("is_duplicate_request", true))
+		}
 	}
 	return h.inner.Handle(ctx, r)
 }

--- a/pkg/engines/traffic-replication/traffic_replication.go
+++ b/pkg/engines/traffic-replication/traffic_replication.go
@@ -102,7 +102,7 @@ func CloneForReplication(req *octollm.Request, expiration time.Duration) (clone 
 		if bodyBytes, err := req.Body.Bytes(); err == nil {
 			bytesCopy := make([]byte, len(bodyBytes))
 			copy(bytesCopy, bodyBytes)
-			clone.Body = octollm.NewBodyFromBytes(bytesCopy, nil)
+			clone.Body = octollm.NewBodyFromBytes(bytesCopy, req.Body.Parser())
 		}
 	}
 

--- a/pkg/engines/traffic-replication/traffic_replication.go
+++ b/pkg/engines/traffic-replication/traffic_replication.go
@@ -16,11 +16,18 @@ import (
 // that have already been replicated, preventing infinite replication loops.
 type trafficReplicationMetadataKey string
 
+type isDuplicateRequestContextKey = string
+
 const (
 	IsTrafficReplication trafficReplicationMetadataKey = "is_traffic_replication"
 
 	// DefaultReplicationExpiration is used when expiration <= 0.
 	DefaultReplicationExpiration = 10 * time.Minute
+
+	// IsDuplicateRequest is stored in the cloned request's context.
+	// contextFieldsHandler reads this key to add a "is_duplicate_request" field
+	// to log entries, indicating the log came from a replicated (cloned) request.
+	IsDuplicateRequest isDuplicateRequestContextKey = "is_duplicate_request"
 )
 
 // TrafficReplicationTarget defines a replication target with a sampling ratio.
@@ -62,7 +69,8 @@ func CloneForReplication(req *octollm.Request, expiration time.Duration) (clone 
 	if expiration <= 0 {
 		expiration = DefaultReplicationExpiration
 	}
-	ctx := context.WithoutCancel(req.Context())
+	ctx := context.WithValue(req.Context(), IsDuplicateRequest, true)
+	ctx = context.WithoutCancel(ctx)
 	ctx, cancel = context.WithDeadline(ctx, time.Now().Add(expiration))
 	clone = req.WithContext(ctx)
 

--- a/pkg/octollm/request.go
+++ b/pkg/octollm/request.go
@@ -148,6 +148,11 @@ func (b *UnifiedBody) Reader() (io.ReadCloser, error) {
 	return io.NopCloser(bytes.NewReader(data)), nil
 }
 
+// Parser returns the parser associated with this body.
+func (b *UnifiedBody) Parser() Parser {
+	return b.parser
+}
+
 // SetParser set the parser and reset the cached state
 func (b *UnifiedBody) SetParser(p Parser) {
 	b.parser = p


### PR DESCRIPTION
Note: this is separate from the existing is_traffic_replication metadata key, which marks requests to prevent infinite replication loops — is_duplicate_request carries no functional role and exists solely for observability(slog field in this case).