### PR TITLE
feat(load-balancer): support cache aware load balancing

### DIFF
--- a/cmd/mock/main.go
+++ b/cmd/mock/main.go
@@ -19,6 +19,7 @@ func main() {
 	exprenv.RegisterDefaultExtractor("prefix20", &ruleengine.PrefixHashExtractor{Length: 20})
 	exprenv.RegisterDefaultExtractor("suffix20", &ruleengine.SuffixHashExtractor{Length: 20})
 	exprenv.RegisterDefaultExtractor("message5Hash", &ruleengine.Message5HashExtractor{})
+	exprenv.RegisterDefaultExtractor("message5HashArray", &ruleengine.Message5HashArrayExtractor{})
 
 	engine := mock.NewWithFixedOutput(`
 归档

--- a/cmd/octollm-server/main.go
+++ b/cmd/octollm-server/main.go
@@ -11,15 +11,17 @@ import (
 	"syscall"
 	"time"
 
+	_ "net/http/pprof"
+
 	"github.com/gin-contrib/gzip"
 	ginslog "github.com/gin-contrib/slog"
 	"github.com/gin-gonic/gin"
+	"github.com/mattn/go-isatty"
+	"go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin"
+
 	"github.com/infinigence/octollm/pkg/composer"
 	ruleengine "github.com/infinigence/octollm/pkg/engines/rule-engine"
 	exprenv "github.com/infinigence/octollm/pkg/exprenv"
-	"github.com/mattn/go-isatty"
-	"go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin"
-	_ "net/http/pprof"
 )
 
 func main() {
@@ -83,6 +85,7 @@ func main() {
 	exprenv.RegisterDefaultExtractor("prefix20", &ruleengine.PrefixHashExtractor{Length: 20})
 	exprenv.RegisterDefaultExtractor("suffix20", &ruleengine.SuffixHashExtractor{Length: 20})
 	exprenv.RegisterDefaultExtractor("message5Hash", &ruleengine.Message5HashExtractor{})
+	exprenv.RegisterDefaultExtractor("message5HashArray", &ruleengine.Message5HashArrayExtractor{})
 
 	s := NewServer(conf)
 

--- a/pkg/engines/load-balancer/shard_key_round_robin.go
+++ b/pkg/engines/load-balancer/shard_key_round_robin.go
@@ -27,6 +27,7 @@ type ShardKeyWeightedRoundRobin struct {
 	shardKeyListGetter func(req *octollm.Request) []string
 	redisClient        *redis.Client
 	shardKeyTTL        time.Duration
+	keyPrefix          string
 
 	retryTimeout  time.Duration
 	retryMaxCount int
@@ -48,6 +49,7 @@ var _ octollm.Engine = (*ShardKeyWeightedRoundRobin)(nil)
 //   - minWeightMultiple: used to compute the lower bound threshold = -minWeightMultiple * totalWeight
 //   - shardKeyList: shard keys for this request (string array, later elements have higher priority)
 //   - redisClient: Redis client, used to resolve shard keys to backend names with pipeline
+//   - keyPrefix: prefix prepended to all Redis keys to namespace shard keys per model/instance
 func NewShardKeyWeightedRoundRobin(
 	backends []BackendItem,
 	retryTimeout time.Duration,
@@ -56,6 +58,7 @@ func NewShardKeyWeightedRoundRobin(
 	minWeightMultiple int,
 	shardKeyListGetter func(req *octollm.Request) []string,
 	redisClient *redis.Client,
+	keyPrefix string,
 ) (*ShardKeyWeightedRoundRobin, error) {
 	if len(backends) == 0 {
 		return nil, fmt.Errorf("backends must have at least one item")
@@ -92,12 +95,20 @@ func NewShardKeyWeightedRoundRobin(
 		shardKeyListGetter: shardKeyListGetter,
 		redisClient:        redisClient,
 		shardKeyTTL:        shardKeyTTL,
+		keyPrefix:          keyPrefix,
 		retryTimeout:       retryTimeout,
 		retryMaxCount:      retryMaxCount,
 		minWeightMultiple:  minWeightMultiple,
 	}
 
 	return lb, nil
+}
+
+func (l *ShardKeyWeightedRoundRobin) redisKey(shardKey string) string {
+	if l.keyPrefix == "" {
+		return shardKey
+	}
+	return l.keyPrefix + ":" + shardKey
 }
 
 // resolvePrioritizedBackends resolves shardKeyList -> backendName via Redis ZSETs and returns
@@ -119,7 +130,7 @@ func (l *ShardKeyWeightedRoundRobin) resolvePrioritizedBackends(
 			continue
 		}
 		// Get all members ordered from newest to oldest (by score).
-		cmds[i] = readPipe.ZRevRange(ctx, shardKey, 0, -1)
+		cmds[i] = readPipe.ZRevRange(ctx, l.redisKey(shardKey), 0, -1)
 	}
 
 	if _, err := readPipe.Exec(ctx); err != nil && err != redis.Nil {
@@ -154,7 +165,7 @@ func (l *ShardKeyWeightedRoundRobin) resolvePrioritizedBackends(
 			// Remove ranks [0, len-4] so that only the latest 3 remain.
 			stop := int64(len(backendNames) - 4)
 			if stop >= 0 {
-				trimPipe.ZRemRangeByRank(ctx, shardKeyList[i], 0, stop)
+				trimPipe.ZRemRangeByRank(ctx, l.redisKey(shardKeyList[i]), 0, stop)
 			}
 		}
 		// backendNames are already ordered from most recent to oldest
@@ -215,11 +226,11 @@ func (l *ShardKeyWeightedRoundRobin) Process(req *octollm.Request) (*octollm.Res
 					if shardKey == "" {
 						continue
 					}
-					pipe.ZAdd(req.Context(), shardKey, redis.Z{
+					pipe.ZAdd(req.Context(), l.redisKey(shardKey), redis.Z{
 						Score:  float64(time.Now().Unix()),
 						Member: n,
 					})
-					pipe.Expire(req.Context(), shardKey, l.shardKeyTTL)
+					pipe.Expire(req.Context(), l.redisKey(shardKey), l.shardKeyTTL)
 				}
 				if _, err := pipe.Exec(req.Context()); err != nil && err != redis.Nil {
 					slog.WarnContext(req.Context(), fmt.Sprintf("[ShardKey WRR load balancer] failed to update shard key mapping in Redis: %v", err))

--- a/pkg/engines/load-balancer/shard_key_round_robin_test.go
+++ b/pkg/engines/load-balancer/shard_key_round_robin_test.go
@@ -43,7 +43,7 @@ func TestNewShardKeyWeightedRoundRobin_Validation(t *testing.T) {
 	backendEngine := &stubEngine{}
 
 	// empty backends
-	_, err := NewShardKeyWeightedRoundRobin(nil, time.Second, 1, time.Minute, 5, nil, nil)
+	_, err := NewShardKeyWeightedRoundRobin(nil, time.Second, 1, time.Minute, 5, nil, nil, "")
 	assert.Error(t, err)
 
 	// negative weight
@@ -51,7 +51,7 @@ func TestNewShardKeyWeightedRoundRobin_Validation(t *testing.T) {
 		[]BackendItem{
 			{Name: "b1", Weight: -1, Engine: backendEngine},
 		},
-		time.Second, 1, time.Minute, 5, nil, nil,
+		time.Second, 1, time.Minute, 5, nil, nil, "",
 	)
 	assert.Error(t, err)
 
@@ -61,7 +61,7 @@ func TestNewShardKeyWeightedRoundRobin_Validation(t *testing.T) {
 			{Name: "b1", Weight: 0, Engine: backendEngine},
 			{Name: "b2", Weight: 0, Engine: backendEngine},
 		},
-		time.Second, 1, time.Minute, 5, nil, nil,
+		time.Second, 1, time.Minute, 5, nil, nil, "",
 	)
 	assert.NoError(t, err)
 	if assert.Len(t, lb.backends, 2) {
@@ -243,6 +243,7 @@ func TestShardKeyWeightedRoundRobin_Process_SuccessAndRedisUpdate(t *testing.T) 
 			return []string{"shard-key-1"}
 		},
 		client,
+		"model-prefix",
 	)
 	assert.NoError(t, err)
 
@@ -260,13 +261,13 @@ func TestShardKeyWeightedRoundRobin_Process_SuccessAndRedisUpdate(t *testing.T) 
 
 	// Redis ZSET should be updated
 	ctx := context.Background()
-	members, err := client.ZRange(ctx, "shard-key-1", 0, -1).Result()
+	members, err := client.ZRange(ctx, "model-prefix:shard-key-1", 0, -1).Result()
 	assert.NoError(t, err)
 	if assert.Len(t, members, 1) {
 		assert.Equal(t, "backend1", members[0])
 	}
 
-	ttl, err := client.TTL(ctx, "shard-key-1").Result()
+	ttl, err := client.TTL(ctx, "model-prefix:shard-key-1").Result()
 	assert.NoError(t, err)
 	assert.Greater(t, ttl, time.Duration(0))
 }

--- a/pkg/engines/rule-engine/simple_features.go
+++ b/pkg/engines/rule-engine/simple_features.go
@@ -106,6 +106,43 @@ func (e *SuffixHashExtractor) Features(req *octollm.Request) (any, error) {
 	}
 }
 
+// Message5HashExtractor produces a composite hash of the first 5 messages: for each message
+// takes the first 100 bytes of text (from Content or first tool call's Arguments), feeds
+// them into FNV-32a cumulatively, and returns the hex hashes joined by "-" (e.g. "a1b2c3d4-e5f6a7b8-...").
+type Message5HashExtractor struct{}
+
+func (e *Message5HashExtractor) Features(req *octollm.Request) (any, error) {
+	reqBody, err := req.Body.Parsed()
+	if err != nil {
+		return nil, fmt.Errorf("parse request body failed: %w", err)
+	}
+
+	switch v := reqBody.(type) {
+	case *openai.ChatCompletionRequest:
+		return strings.Join(computeMessage5Hashes(v.Messages), "-"), nil
+	default:
+		return nil, fmt.Errorf("unsupported request body type %T", reqBody)
+	}
+}
+
+// Message5HashArrayExtractor produces the same hashes as Message5HashExtractor but returns []string
+// instead of a joined string.
+type Message5HashArrayExtractor struct{}
+
+func (e *Message5HashArrayExtractor) Features(req *octollm.Request) (any, error) {
+	reqBody, err := req.Body.Parsed()
+	if err != nil {
+		return nil, fmt.Errorf("parse request body failed: %w", err)
+	}
+
+	switch v := reqBody.(type) {
+	case *openai.ChatCompletionRequest:
+		return computeMessage5Hashes(v.Messages), nil
+	default:
+		return nil, fmt.Errorf("unsupported request body type %T", reqBody)
+	}
+}
+
 // messageTextForHash returns text from a message for hashing: Content.ExtractText(), or if empty
 // and the message has ToolCalls, the first tool call's Function.Arguments.
 func messageTextForHash(msg *openai.Message) string {
@@ -123,42 +160,26 @@ func messageTextForHash(msg *openai.Message) string {
 	return ""
 }
 
-// Message5HashExtractor produces a composite hash of the first 5 messages: for each message
-// takes the first 100 bytes of text (from Content or first tool call's Arguments), feeds
-// them into FNV-32a cumulatively, and returns the hex hashes joined by "-" (e.g. "a1b2c3d4-e5f6a7b8-...").
-type Message5HashExtractor struct{}
-
-func (e *Message5HashExtractor) Features(req *octollm.Request) (any, error) {
-	reqBody, err := req.Body.Parsed()
-	if err != nil {
-		return nil, fmt.Errorf("parse request body failed: %w", err)
-	}
-
-	switch v := reqBody.(type) {
-	case *openai.ChatCompletionRequest:
-		if len(v.Messages) == 0 {
-			return "", nil
+// computeMessage5Hashes computes cumulative FNV-32a hashes over the first 5 non-empty messages,
+// taking the first 100 bytes of each message's text. Returns hex hash strings in order.
+func computeMessage5Hashes(messages []*openai.Message) []string {
+	hasher := fnv.New32a()
+	hashes := make([]string, 0, 5)
+	for i := 0; i < len(messages) && len(hashes) < 5; i++ {
+		msg := messages[i]
+		if msg == nil {
+			continue
 		}
-		hasher := fnv.New32a()
-		hashes := make([]string, 0, 5)
-		for i := 0; i < len(v.Messages) && len(hashes) < 5; i++ {
-			msg := v.Messages[i]
-			if msg == nil {
-				continue
-			}
-			msgTxt := messageTextForHash(msg)
-			if msgTxt == "" {
-				continue
-			}
-			prefix := []byte(msgTxt)
-			if len(prefix) > 100 {
-				prefix = prefix[:100]
-			}
-			hasher.Write(prefix)
-			hashes = append(hashes, fmt.Sprintf("%08x", hasher.Sum32()))
+		msgTxt := messageTextForHash(msg)
+		if msgTxt == "" {
+			continue
 		}
-		return strings.Join(hashes, "-"), nil
-	default:
-		return nil, fmt.Errorf("unsupported request body type %T", reqBody)
+		prefix := []byte(msgTxt)
+		if len(prefix) > 100 {
+			prefix = prefix[:100]
+		}
+		hasher.Write(prefix)
+		hashes = append(hashes, fmt.Sprintf("%08x", hasher.Sum32()))
 	}
+	return hashes
 }

--- a/pkg/engines/rule-engine/simple_features_test.go
+++ b/pkg/engines/rule-engine/simple_features_test.go
@@ -1,17 +1,17 @@
 package ruleengine
 
 import (
+	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/infinigence/octollm/pkg/internal/testhelper"
 	"github.com/infinigence/octollm/pkg/types/openai"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
-func TestMessage5HashExtractor_Features(t *testing.T) {
-	extractor := &Message5HashExtractor{}
-
+func TestMessage5Hash_Features(t *testing.T) {
 	type testCase struct {
 		name     string
 		req      *openai.ChatCompletionRequest
@@ -217,13 +217,34 @@ func TestMessage5HashExtractor_Features(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			req := testhelper.CreateTestRequest(testhelper.WithBody(tc.req))
-			val, err := extractor.Features(req)
-			require.NoError(t, err)
-			str, _ := val.(string)
-			assert.Equal(t, tc.expected, str, "message5Hash mismatch")
-		})
-	}
+	t.Run("string", func(t *testing.T) {
+		extractor := &Message5HashExtractor{}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				req := testhelper.CreateTestRequest(testhelper.WithBody(tc.req))
+				val, err := extractor.Features(req)
+				require.NoError(t, err)
+				str, _ := val.(string)
+				assert.Equal(t, tc.expected, str, "message5Hash mismatch")
+			})
+		}
+	})
+
+	t.Run("array", func(t *testing.T) {
+		extractor := &Message5HashArrayExtractor{}
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				req := testhelper.CreateTestRequest(testhelper.WithBody(tc.req))
+				val, err := extractor.Features(req)
+				require.NoError(t, err)
+				if tc.expected == "" {
+					assert.Empty(t, val, "message5HashArray should be empty")
+				} else {
+					expectedArray := strings.Split(tc.expected, "-")
+					assert.Equal(t, expectedArray, val, "message5HashArray mismatch")
+				}
+			})
+		}
+	})
 }


### PR DESCRIPTION
1. Adds a keyPrefix parameter that is prepended to all Redis shard key operations (ZRevRange, ZRemRangeByRank, ZAdd, Expire) so that different models using the same shard keys do not collide in Redis.

2. add Message5HashArrayExtractor