### PR TITLE
feat(load-balancer): treat zero-weight backends as last-resort failover

### DIFF
--- a/pkg/engines/load-balancer/round_robin.go
+++ b/pkg/engines/load-balancer/round_robin.go
@@ -23,6 +23,10 @@ type wrrBackend struct {
 	currentWeight int
 }
 
+func (b *wrrBackend) String() string {
+	return fmt.Sprintf("{%s w=%d cw=%d}", b.name, b.weight, b.currentWeight)
+}
+
 type WeightedRoundRobin struct {
 	mu       sync.Mutex
 	backends []*wrrBackend

--- a/pkg/engines/load-balancer/shard_key_round_robin.go
+++ b/pkg/engines/load-balancer/shard_key_round_robin.go
@@ -31,10 +31,6 @@ type ShardKeyWeightedRoundRobin struct {
 
 	retryTimeout  time.Duration
 	retryMaxCount int
-
-	// minWeightMultiple controls the lower bound for currentWeight:
-	// a backend is temporarily not selectable when currentWeight < -minWeightMultiple * totalWeight.
-	minWeightMultiple int
 }
 
 var _ octollm.Engine = (*ShardKeyWeightedRoundRobin)(nil)
@@ -46,7 +42,6 @@ var _ octollm.Engine = (*ShardKeyWeightedRoundRobin)(nil)
 //   - retryTimeout: maximum time to retry failed requests
 //   - retryMaxCount: maximum number of retries
 //   - shardKeyTTL: expiration time for shard key -> backend mapping in Redis
-//   - minWeightMultiple: used to compute the lower bound threshold = -minWeightMultiple * totalWeight
 //   - shardKeyList: shard keys for this request (string array, later elements have higher priority)
 //   - redisClient: Redis client, used to resolve shard keys to backend names with pipeline
 //   - keyPrefix: prefix prepended to all Redis keys to namespace shard keys per model/instance
@@ -55,7 +50,6 @@ func NewShardKeyWeightedRoundRobin(
 	retryTimeout time.Duration,
 	retryMaxCount int,
 	shardKeyTTL time.Duration,
-	minWeightMultiple int,
 	shardKeyListGetter func(req *octollm.Request) []string,
 	redisClient *redis.Client,
 	keyPrefix string,
@@ -98,7 +92,6 @@ func NewShardKeyWeightedRoundRobin(
 		keyPrefix:          keyPrefix,
 		retryTimeout:       retryTimeout,
 		retryMaxCount:      retryMaxCount,
-		minWeightMultiple:  minWeightMultiple,
 	}
 
 	return lb, nil
@@ -274,10 +267,9 @@ func (l *ShardKeyWeightedRoundRobin) Process(req *octollm.Request) (*octollm.Res
 
 // GetNextEngine applies the shard-key aware WRR selection.
 // Step for each pick:
-//  1. Compute totalWeight and threshold = -minWeightMultiple * totalWeight.
-//  2. If prioritizedBackend is non-empty and its backend's currentWeight >= threshold, pick it;
-//     otherwise pick the backend with the largest currentWeight among those whose currentWeight >= threshold,
-//     skipping any backend in excludeNames.
+//  1. Compute totalWeight.
+//  2. If prioritizedBackend is non-empty, pick it directly;
+//     otherwise pick the backend with the largest currentWeight among non-excluded backends.
 //  3. For the selected backend, subtract totalWeight from its currentWeight.
 //  4. Then, for all backends, add their own weight once (currentWeight += weight).
 func (l *ShardKeyWeightedRoundRobin) GetNextEngine(ctx context.Context, prioritizedBackend string, excludeNames map[string]bool) (string, octollm.Engine) {
@@ -294,13 +286,8 @@ func (l *ShardKeyWeightedRoundRobin) GetNextEngine(ctx context.Context, prioriti
 	if totalWeight <= 0 {
 		return "", nil
 	}
-	multiple := l.minWeightMultiple
-	if multiple <= 0 {
-		multiple = 5
-	}
-	threshold := -multiple * totalWeight
 
-	// Try shard-hit backend first (if any) and if it hasn't dropped below threshold.
+	// Try shard-hit backend first (if any).
 	var selected *wrrBackend
 	if prioritizedBackend != "" {
 		for _, backend := range l.backends {
@@ -308,9 +295,7 @@ func (l *ShardKeyWeightedRoundRobin) GetNextEngine(ctx context.Context, prioriti
 				continue
 			}
 			if backend.name == prioritizedBackend {
-				if backend.currentWeight >= threshold {
-					selected = backend
-				}
+				selected = backend
 				break
 			}
 		}
@@ -323,9 +308,6 @@ func (l *ShardKeyWeightedRoundRobin) GetNextEngine(ctx context.Context, prioriti
 				continue
 			}
 			if excludeNames[backend.name] {
-				continue
-			}
-			if backend.currentWeight < threshold {
 				continue
 			}
 			if selected == nil || backend.currentWeight > selected.currentWeight {

--- a/pkg/engines/load-balancer/shard_key_round_robin.go
+++ b/pkg/engines/load-balancer/shard_key_round_robin.go
@@ -166,7 +166,7 @@ func (l *ShardKeyWeightedRoundRobin) resolvePrioritizedBackends(
 			if backendName == "" || seen[backendName] {
 				continue
 			}
-			if backend, ok := backendByName[backendName]; ok {
+			if backend, ok := backendByName[backendName]; ok && backend.weight > 0 {
 				prioritizedBackends = append(prioritizedBackends, backend)
 				seen[backendName] = true
 			}
@@ -205,7 +205,7 @@ func (l *ShardKeyWeightedRoundRobin) Process(req *octollm.Request) (*octollm.Res
 			prioritizedIndex++
 		}
 
-		n, eng := l.GetNextEngine(req.Context(), prioritizedBackend, excludeNames)
+		n, eng, isAllZero := l.GetNextEngine(req.Context(), prioritizedBackend, excludeNames)
 		if eng == nil {
 			// should not happen: the loop exits before all backends are excluded (line 264 above); panic guard only
 			return nil, fmt.Errorf("no backend engine available")
@@ -219,7 +219,7 @@ func (l *ShardKeyWeightedRoundRobin) Process(req *octollm.Request) (*octollm.Res
 		resp, err := eng.Process(req)
 		if err == nil {
 			// Update Redis: shardKeyList -> ZSET of backend names (score = current timestamp), with configured TTL.
-			if l.redisClient != nil && len(shardKeyList) > 0 && l.shardKeyTTL > 0 {
+			if l.redisClient != nil && len(shardKeyList) > 0 && l.shardKeyTTL > 0 && !isAllZero {
 				pipe := l.redisClient.Pipeline()
 				for _, shardKey := range shardKeyList {
 					if shardKey == "" {
@@ -266,48 +266,57 @@ func (l *ShardKeyWeightedRoundRobin) Process(req *octollm.Request) (*octollm.Res
 }
 
 // GetNextEngine applies the shard-key aware WRR selection.
-// Step for each pick:
-//  1. Compute totalWeight.
-//  2. If prioritizedBackend is non-empty, pick it directly;
-//     otherwise pick the backend with the largest currentWeight among non-excluded backends.
-//  3. For the selected backend, subtract totalWeight from its currentWeight.
-//  4. Then, for all backends, add their own weight once (currentWeight += weight).
-func (l *ShardKeyWeightedRoundRobin) GetNextEngine(ctx context.Context, prioritizedBackend string, excludeNames map[string]bool) (string, octollm.Engine) {
+// Per-pick algorithm:
+//  1. Build candidates: non-excluded backends with weight >= 0. Compute totalWeight.
+//  2. If totalWeight == 0 (all-zero weights), pick a random candidate and return immediately
+//     — no WRR state is mutated.
+//  3. Otherwise, try prioritizedBackend first (if set); fall back to the candidate with
+//     the highest currentWeight.
+//  4. Penalize selected: selected.currentWeight -= totalWeight.
+//  5. Accumulate: every non-zero-weight candidate adds its own weight to currentWeight.
+func (l *ShardKeyWeightedRoundRobin) GetNextEngine(ctx context.Context, prioritizedBackend string, excludeNames map[string]bool) (string, octollm.Engine, bool) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
 	totalWeight := 0
+	var candidates []*wrrBackend
 	for _, backend := range l.backends {
-		if backend == nil || backend.weight <= 0 {
+		if backend == nil || backend.weight < 0 {
+			continue
+		}
+		if excludeNames[backend.name] {
 			continue
 		}
 		totalWeight += backend.weight
+		candidates = append(candidates, backend)
 	}
-	if totalWeight <= 0 {
-		return "", nil
+	isAllZero := totalWeight == 0
+
+	// When all weights are zero, pick randomly — no WRR penalty needed.
+	if isAllZero {
+		if len(candidates) == 0 {
+			return "", nil, true
+		}
+		selected := candidates[rand.Intn(len(candidates))]
+		slog.InfoContext(ctx, fmt.Sprintf("[ShardKey WRR load balancer] all-zero weights, random pick: %s, candidates: %v", selected.name, candidates))
+		return selected.name, selected.engine, true
 	}
 
-	// Try shard-hit backend first (if any).
+	// Step 2a: try the prioritized (shard-hit) backend first.
 	var selected *wrrBackend
 	if prioritizedBackend != "" {
-		for _, backend := range l.backends {
-			if backend == nil || backend.weight <= 0 {
-				continue
-			}
-			if backend.name == prioritizedBackend {
+		for _, backend := range candidates {
+			if backend.name == prioritizedBackend && backend.weight > 0 {
 				selected = backend
 				break
 			}
 		}
 	}
 
-	// Fallback to normal WRR among non-excluded backends whose currentWeight >= threshold.
+	// Step 2b: fall back to normal WRR — pick non-excluded backend with highest currentWeight.
 	if selected == nil {
-		for _, backend := range l.backends {
-			if backend == nil || backend.weight <= 0 {
-				continue
-			}
-			if excludeNames[backend.name] {
+		for _, backend := range candidates {
+			if backend.weight == 0 {
 				continue
 			}
 			if selected == nil || backend.currentWeight > selected.currentWeight {
@@ -317,33 +326,21 @@ func (l *ShardKeyWeightedRoundRobin) GetNextEngine(ctx context.Context, prioriti
 	}
 
 	if selected == nil {
-		return "", nil
+		return "", nil, false
 	}
 
-	// Capture weight snapshot of remaining candidates (inside lock, before weight update).
-	type snapshot struct {
-		name          string
-		currentWeight int
-	}
-	candidates := make([]snapshot, 0, len(l.backends))
-	for _, backend := range l.backends {
-		if backend == nil || excludeNames[backend.name] {
-			continue
-		}
-		candidates = append(candidates, snapshot{name: backend.name, currentWeight: backend.currentWeight})
-	}
 	slog.InfoContext(ctx, fmt.Sprintf("[ShardKey WRR load balancer] selected: %s (currentWeight=%d), candidates: %v", selected.name, selected.currentWeight, candidates))
 
-	// Step 3: subtract totalWeight from selected backend.
+	// Step 3: penalize selected backend by totalWeight.
 	selected.currentWeight -= totalWeight
 
-	// Step 4: then every backend adds its own weight once.
-	for _, backend := range l.backends {
+	// Step 4: accumulate weight for all non-zero-weight backends.
+	for _, backend := range candidates {
 		if backend == nil || backend.weight <= 0 {
 			continue
 		}
 		backend.currentWeight += backend.weight
 	}
 
-	return selected.name, selected.engine
+	return selected.name, selected.engine, false
 }

--- a/pkg/engines/load-balancer/shard_key_round_robin_test.go
+++ b/pkg/engines/load-balancer/shard_key_round_robin_test.go
@@ -98,23 +98,23 @@ func TestResolvePrioritizedBackends_WithRedisAndTrim(t *testing.T) {
 
 	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
 
-	backends := []*wrrBackend{
-		{name: "b1"},
-		{name: "b2"},
-		{name: "b3"},
-		{name: "b4"},
-		{name: "b5"},
+	backends := []BackendItem{
+		{Name: "b1"},
+		{Name: "b2"},
+		{Name: "b3"},
+		{Name: "b4"},
+		{Name: "b5"},
 	}
-	lb := &ShardKeyWeightedRoundRobin{
-		backends:    backends,
-		redisClient: client,
-	}
+	lb, err := NewShardKeyWeightedRoundRobin(
+		backends, 5*time.Second, 5, 5*time.Minute, nil, client, "",
+	)
+	require.NoError(t, err)
 
 	ctx := context.Background()
 	now := time.Now().Unix()
 
 	// k1 has 2 members
-	_, err := client.ZAdd(ctx, "k1",
+	_, err = client.ZAdd(ctx, "k1",
 		redis.Z{Score: float64(now - 10), Member: "b1"},
 		redis.Z{Score: float64(now - 5), Member: "b2"},
 	).Result()
@@ -159,7 +159,7 @@ func TestGetNextEngine_PrioritizedHit(t *testing.T) {
 		},
 	}
 
-	name, eng := lb.GetNextEngine(context.Background(), "b", nil)
+	name, eng, _ := lb.GetNextEngine(context.Background(), "b", nil)
 	assert.Equal(t, "b", name)
 	assert.Equal(t, e2, eng)
 
@@ -169,17 +169,18 @@ func TestGetNextEngine_PrioritizedHit(t *testing.T) {
 	assert.NotZero(t, lb.backends[0].currentWeight)
 }
 
-func TestGetNextEngine_NoEligibleBackend(t *testing.T) {
+func TestGetNextEngine_AllWeightZeroBackends(t *testing.T) {
 	lb := &ShardKeyWeightedRoundRobin{
 		backends: []*wrrBackend{
-			// weight <= 0 -> ignored
 			{name: "a", weight: 0, engine: &stubEngine{}, currentWeight: 0},
+			{name: "b", weight: 0, engine: &stubEngine{}, currentWeight: 0},
 		},
 	}
 
-	name, eng := lb.GetNextEngine(context.Background(), "", nil)
-	assert.Equal(t, "", name)
-	assert.Nil(t, eng)
+	name, eng, _ := lb.GetNextEngine(context.Background(), "", nil)
+	assert.NotEmpty(t, name)
+	assert.Contains(t, []string{"a", "b"}, name)
+	assert.NotNil(t, eng)
 }
 
 type failingReader struct{}
@@ -324,7 +325,7 @@ func TestGetNextEngine_SmoothWeightedRoundRobin_NoShard(t *testing.T) {
 	sequence := make([]string, 0, totalPicks)
 
 	for i := 0; i < totalPicks; i++ {
-		name, eng := lb.GetNextEngine(context.Background(), "", nil)
+		name, eng, _ := lb.GetNextEngine(context.Background(), "", nil)
 		assert.NotEmpty(t, name)
 		assert.NotNil(t, eng)
 		counts[name]++
@@ -405,5 +406,91 @@ func TestShardKeyWeightedRoundRobin_Process_AllBackendExhausted(t *testing.T) {
 
 		assert.Greater(t, stubA.lastCalledTs, stubB.lastCalledTs, "stubA and stubB should be called in order of prioritization")
 		assert.Greater(t, stubB.lastCalledTs, stubC.lastCalledTs, "stubB and stubC should be called in order of prioritization")
+	})
+}
+
+func TestShardKeyWeightedRoundRobin_Process_FailoverToZeroWeightedBackend(t *testing.T) {
+	mr := miniredis.RunT(t)
+	defer mr.Close()
+	rd := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+
+	stubA := &stubEngine{err: errors.New("failure")}
+	stubB := &stubEngine{err: errors.New("failure")}
+	stubC := &stubEngine{}
+
+	lbItems := []BackendItem{
+		{Name: "A", Weight: 10, Engine: stubA},
+		{Name: "B", Weight: 5, Engine: stubB},
+		{Name: "C", Weight: 0, Engine: stubC},
+	}
+	shardKeyListFunc := func(req *octollm.Request) []string {
+		return []string{"shard-key-1"}
+	}
+	lb, err := NewShardKeyWeightedRoundRobin(lbItems, time.Second, 5, time.Minute, shardKeyListFunc, rd, "shard-key:failover-zero-weight")
+	require.NoError(t, err)
+
+	t.Run("weighted backends fail, zero-weight backend succeeds", func(t *testing.T) {
+		// A B should be tried first (in order of prioritization), then failover to C which has zero weight but should still be tried and succeed
+		req := testhelper.CreateTestRequest()
+		resp, err := lb.Process(req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		// All backends should have been tried once
+		assert.Equal(t, 1, stubA.callCount, "stubA should be called once")
+		assert.Equal(t, 1, stubB.callCount, "stubB should be called once")
+		assert.Equal(t, 1, stubC.callCount, "stubC should be called once")
+	})
+
+	stubA.reset()
+	stubB.reset()
+	stubC.reset()
+
+	t.Run("shard-key prioritizes weighted backends, zero-weight backend succeeds as last resort", func(t *testing.T) {
+		ctx := context.Background()
+		// b -> a -> c
+		_, err = rd.ZAdd(ctx, "shard-key:failover-zero-weight:shard-key-1",
+			redis.Z{Score: float64(time.Now().Unix() - 2), Member: "A"},
+			redis.Z{Score: float64(time.Now().Unix() - 1), Member: "B"},
+			redis.Z{Score: float64(time.Now().Unix()), Member: "C"},
+		).Result()
+		require.NoError(t, err)
+
+		req := testhelper.CreateTestRequest()
+		resp, err := lb.Process(req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		assert.Equal(t, 1, stubA.callCount, "stubA should be called once")
+		assert.Equal(t, 1, stubB.callCount, "stubB should be called once")
+		assert.Equal(t, 1, stubC.callCount, "stubC should be called once")
+
+		assert.Greater(t, stubA.lastCalledTs, stubB.lastCalledTs, "stubA and stubB should be called in order of prioritization")
+		assert.Greater(t, stubC.lastCalledTs, stubB.lastCalledTs, "stubC should be called for failover after stubB")
+	})
+}
+
+func TestShardKeyhWeightedRoundRobin_Process_ZeroWeightEngineNotFirstChoice(t *testing.T) {
+	stubA := &stubEngine{}
+	stubB := &stubEngine{}
+	stubC := &stubEngine{}
+
+	lbItems := []BackendItem{
+		{Name: "A", Weight: 10, Engine: stubA},
+		{Name: "B", Weight: 5, Engine: stubB},
+		{Name: "C", Weight: 0, Engine: stubC},
+	}
+
+	lb, err := NewShardKeyWeightedRoundRobin(lbItems, time.Second, 5, time.Minute, nil, nil, "")
+	require.NoError(t, err)
+
+	t.Run("shard-key prioritizes weighted backends, zero-weight backend succeeds as last resort", func(t *testing.T) {
+		for range 5 {
+			req := testhelper.CreateTestRequest()
+			resp, err := lb.Process(req)
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+		}
+		assert.Equal(t, 0, stubC.callCount, "stubC with zero weight should not be called when other weighted backends are available and healthy")
+		assert.Equal(t, 5, stubA.callCount+stubB.callCount, "stubA and stubB should be called for all requests since they are healthy and have non-zero weight")
 	})
 }

--- a/pkg/engines/load-balancer/shard_key_round_robin_test.go
+++ b/pkg/engines/load-balancer/shard_key_round_robin_test.go
@@ -54,7 +54,7 @@ func TestNewShardKeyWeightedRoundRobin_Validation(t *testing.T) {
 	backendEngine := &stubEngine{}
 
 	// empty backends
-	_, err := NewShardKeyWeightedRoundRobin(nil, time.Second, 1, time.Minute, 5, nil, nil, "")
+	_, err := NewShardKeyWeightedRoundRobin(nil, time.Second, 1, time.Minute, nil, nil, "")
 	assert.Error(t, err)
 
 	// negative weight
@@ -62,7 +62,7 @@ func TestNewShardKeyWeightedRoundRobin_Validation(t *testing.T) {
 		[]BackendItem{
 			{Name: "b1", Weight: -1, Engine: backendEngine},
 		},
-		time.Second, 1, time.Minute, 5, nil, nil, "",
+		time.Second, 1, time.Minute, nil, nil, "",
 	)
 	assert.Error(t, err)
 
@@ -72,7 +72,7 @@ func TestNewShardKeyWeightedRoundRobin_Validation(t *testing.T) {
 			{Name: "b1", Weight: 0, Engine: backendEngine},
 			{Name: "b2", Weight: 0, Engine: backendEngine},
 		},
-		time.Second, 1, time.Minute, 5, nil, nil, "",
+		time.Second, 1, time.Minute, nil, nil, "",
 	)
 	assert.NoError(t, err)
 	if assert.Len(t, lb.backends, 2) {
@@ -106,9 +106,8 @@ func TestResolvePrioritizedBackends_WithRedisAndTrim(t *testing.T) {
 		{name: "b5"},
 	}
 	lb := &ShardKeyWeightedRoundRobin{
-		backends:          backends,
-		redisClient:       client,
-		minWeightMultiple: 5,
+		backends:    backends,
+		redisClient: client,
 	}
 
 	ctx := context.Background()
@@ -158,7 +157,6 @@ func TestGetNextEngine_PrioritizedHit(t *testing.T) {
 			{name: "a", weight: 1, engine: e1, currentWeight: 0},
 			{name: "b", weight: 2, engine: e2, currentWeight: 0},
 		},
-		minWeightMultiple: 5,
 	}
 
 	name, eng := lb.GetNextEngine(context.Background(), "b", nil)
@@ -171,32 +169,12 @@ func TestGetNextEngine_PrioritizedHit(t *testing.T) {
 	assert.NotZero(t, lb.backends[0].currentWeight)
 }
 
-func TestGetNextEngine_FallbackWhenPrioritizedBelowThreshold(t *testing.T) {
-	ePrior := &stubEngine{}
-	eOther := &stubEngine{}
-
-	// totalWeight = 1 + 1 = 2, threshold = -10
-	// After adding weight, currentWeight of prioritized backend = -100 + 1 = -99 < threshold
-	lb := &ShardKeyWeightedRoundRobin{
-		backends: []*wrrBackend{
-			{name: "prior", weight: 1, engine: ePrior, currentWeight: -100},
-			{name: "other", weight: 1, engine: eOther, currentWeight: 0},
-		},
-		minWeightMultiple: 5,
-	}
-
-	name, eng := lb.GetNextEngine(context.Background(), "prior", nil)
-	assert.Equal(t, "other", name)
-	assert.Equal(t, eOther, eng)
-}
-
 func TestGetNextEngine_NoEligibleBackend(t *testing.T) {
 	lb := &ShardKeyWeightedRoundRobin{
 		backends: []*wrrBackend{
 			// weight <= 0 -> ignored
 			{name: "a", weight: 0, engine: &stubEngine{}, currentWeight: 0},
 		},
-		minWeightMultiple: 5,
 	}
 
 	name, eng := lb.GetNextEngine(context.Background(), "", nil)
@@ -249,7 +227,6 @@ func TestShardKeyWeightedRoundRobin_Process_SuccessAndRedisUpdate(t *testing.T) 
 		time.Second,
 		3,
 		time.Minute,
-		5,
 		func(req *octollm.Request) []string {
 			return []string{"shard-key-1"}
 		},
@@ -293,9 +270,8 @@ func TestShardKeyWeightedRoundRobin_Process_RetryTimeout(t *testing.T) {
 		backends: []*wrrBackend{
 			{name: "backend1", weight: 1, engine: failEngine},
 		},
-		retryTimeout:      0,
-		retryMaxCount:     10,
-		minWeightMultiple: 5,
+		retryTimeout:  0,
+		retryMaxCount: 10,
 	}
 
 	req := newTestRequest(t)
@@ -317,9 +293,8 @@ func TestShardKeyWeightedRoundRobin_Process_RetryMaxCount(t *testing.T) {
 		backends: []*wrrBackend{
 			{name: "backend1", weight: 1, engine: failEngine},
 		},
-		retryTimeout:      time.Hour,
-		retryMaxCount:     2,
-		minWeightMultiple: 5,
+		retryTimeout:  time.Hour,
+		retryMaxCount: 2,
 	}
 
 	req := newTestRequest(t)
@@ -342,7 +317,6 @@ func TestGetNextEngine_SmoothWeightedRoundRobin_NoShard(t *testing.T) {
 			{name: "B", weight: 3, engine: &stubEngine{}, currentWeight: 0},
 			{name: "C", weight: 5, engine: &stubEngine{}, currentWeight: 0},
 		},
-		minWeightMultiple: 5,
 	}
 
 	const totalPicks = 10 // sum of weights
@@ -375,41 +349,6 @@ func TestGetNextEngine_SmoothWeightedRoundRobin_NoShard(t *testing.T) {
 	}
 }
 
-func TestGetNextEngine_ShardHitEventuallyFallsBackWhenBelowThreshold(t *testing.T) {
-	// Three backends with weights 2,3,5. Prioritized shard always points to A.
-	// With a relatively small minWeightMultiple, A will eventually fall below threshold
-	// and the picker should start choosing other backends even when shard_key keeps hitting A.
-	lb := &ShardKeyWeightedRoundRobin{
-		backends: []*wrrBackend{
-			{name: "A", weight: 2, engine: &stubEngine{}, currentWeight: 0},
-			{name: "B", weight: 3, engine: &stubEngine{}, currentWeight: 0},
-			{name: "C", weight: 5, engine: &stubEngine{}, currentWeight: 0},
-		},
-		minWeightMultiple: 1, // threshold = -1 * totalWeight
-	}
-
-	const iterations = 10
-	sawA := false
-	sawNonAAfterA := false
-
-	for i := 0; i < iterations; i++ {
-		name, eng := lb.GetNextEngine(context.Background(), "A", nil)
-		assert.NotEmpty(t, name)
-		assert.NotNil(t, eng)
-
-		if name == "A" {
-			sawA = true
-		}
-		if sawA && name != "A" {
-			sawNonAAfterA = true
-			break
-		}
-	}
-
-	assert.True(t, sawA, "shard-hit backend A should be selected at least once")
-	assert.True(t, sawNonAAfterA, "after enough hits, selection should eventually fall back to a non-A backend even when shard key keeps hitting A")
-}
-
 func TestShardKeyWeightedRoundRobin_Process_AllBackendExhausted(t *testing.T) {
 	mr := miniredis.RunT(t)
 	defer mr.Close()
@@ -427,7 +366,7 @@ func TestShardKeyWeightedRoundRobin_Process_AllBackendExhausted(t *testing.T) {
 	shardKeyListFunc := func(req *octollm.Request) []string {
 		return []string{"shard-key-1"}
 	}
-	lb, err := NewShardKeyWeightedRoundRobin(lbItems, time.Second, 5, time.Minute, 5, shardKeyListFunc, rd, "shard-key:all-backend-exhausted")
+	lb, err := NewShardKeyWeightedRoundRobin(lbItems, time.Second, 5, time.Minute, shardKeyListFunc, rd, "shard-key:all-backend-exhausted")
 	require.NoError(t, err)
 
 	t.Run("all backends exhausted without shard key prioritization", func(t *testing.T) {

--- a/pkg/engines/load-balancer/shard_key_round_robin_test.go
+++ b/pkg/engines/load-balancer/shard_key_round_robin_test.go
@@ -494,3 +494,107 @@ func TestShardKeyhWeightedRoundRobin_Process_ZeroWeightEngineNotFirstChoice(t *t
 		assert.Equal(t, 5, stubA.callCount+stubB.callCount, "stubA and stubB should be called for all requests since they are healthy and have non-zero weight")
 	})
 }
+
+func TestShardKeyhWeightedRoundRobin_Process_ZeroWeightEngineCanBeLoadBalanced(t *testing.T) {
+	stubA := &stubEngine{err: errors.New("failure")}
+	stubB := &stubEngine{err: errors.New("failure")}
+	stubC := &stubEngine{}
+	stubD := &stubEngine{}
+
+	lbItems := []BackendItem{
+		{Name: "A", Weight: 10, Engine: stubA},
+		{Name: "B", Weight: 5, Engine: stubB},
+		{Name: "C", Weight: 0, Engine: stubC},
+		{Name: "D", Weight: 0, Engine: stubD},
+	}
+
+	lb, err := NewShardKeyWeightedRoundRobin(lbItems, time.Second, 5, time.Minute, nil, nil, "")
+	require.NoError(t, err)
+
+	t.Run("shard-key prioritizes weighted backends, zero-weight backend succeeds as last resort", func(t *testing.T) {
+		for range 100 {
+			req := testhelper.CreateTestRequest()
+			resp, err := lb.Process(req)
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+		}
+		assert.Equal(t, 100, stubA.callCount, "stubA should be called once per request")
+		assert.Equal(t, 100, stubB.callCount, "stubB should be called once per request")
+
+		assert.Equal(t, 100, stubC.callCount+stubD.callCount, "zero-weight backends C and D should handle all 100 requests as fallback")
+
+		assert.InDelta(t, 1.0, float64(stubC.callCount)/float64(stubD.callCount), 0.2, "C and D should be load balanced roughly equally")
+	})
+}
+
+func TestShardKeyWeightedRoundRobin_Process_Priority(t *testing.T) {
+	mr := miniredis.RunT(t)
+	defer mr.Close()
+	rd := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+
+	stubA := &stubEngine{}
+	stubB := &stubEngine{}
+	stubC := &stubEngine{}
+
+	lbItems := []BackendItem{
+		{Name: "A", Weight: 10, Engine: stubA},
+		{Name: "B", Weight: 5, Engine: stubB},
+		{Name: "C", Weight: 0, Engine: stubC},
+	}
+
+	shardKeyListFunc := func(req *octollm.Request) []string {
+		return []string{req.Context().Value("selected-backend").(string)}
+	}
+	ctxA := context.WithValue(context.Background(), "selected-backend", "A")
+	ctxC := context.WithValue(context.Background(), "selected-backend", "C")
+
+	lb, err := NewShardKeyWeightedRoundRobin(lbItems, time.Second, 5, time.Minute, shardKeyListFunc, rd, "shard-key:select-by-ctx")
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	t.Run("redis score is updated after successful processing with shard key prioritization", func(t *testing.T) {
+		initialScore := float64(time.Now().Unix() - 10)
+		_, err = rd.ZAdd(ctx, "shard-key:select-by-ctx:A",
+			redis.Z{Score: initialScore, Member: "A"},
+		).Result()
+		require.NoError(t, err)
+
+		req := testhelper.CreateTestRequest(testhelper.WithContext(ctxA))
+		_, err = lb.Process(req)
+		require.NoError(t, err)
+
+		assert.Equal(t, 1, stubA.callCount, "stubA should be called for shard key prioritization")
+
+		// Score should be updated to a more recent timestamp after successful processing
+		updatedScore, err := rd.ZScore(ctx, "shard-key:select-by-ctx:A", "A").Result()
+		require.NoError(t, err)
+		assert.Greater(t, updatedScore, initialScore, "Redis ZSET score for A should be updated to a more recent timestamp after processing")
+	})
+
+	stubA.reset()
+	stubB.reset()
+	stubA.err = errors.New("failure")
+	stubB.err = errors.New("failure")
+
+	t.Run("redis score is not updated after successful processing for zero-weight backend", func(t *testing.T) {
+		initialScore := float64(time.Now().Unix() - 10)
+		_, err = rd.ZAdd(ctx, "shard-key:select-by-ctx:C",
+			redis.Z{Score: initialScore, Member: "C"},
+		).Result()
+		require.NoError(t, err)
+
+		req := testhelper.CreateTestRequest(testhelper.WithContext(ctxC))
+		_, err = lb.Process(req)
+		require.NoError(t, err)
+
+		assert.Equal(t, 1, stubA.callCount)
+		assert.Equal(t, 1, stubB.callCount)
+		assert.Equal(t, 1, stubC.callCount, "stubC should be called for failover")
+
+		// Score should NOT be updated for zero-weight backends
+		scoreAfter, err := rd.ZScore(ctx, "shard-key:select-by-ctx:C", "C").Result()
+		require.NoError(t, err)
+		assert.Equal(t, initialScore, scoreAfter, "Redis ZSET score for zero-weight backend C should not be updated after processing")
+	})
+}


### PR DESCRIPTION
* remove min factor multiplier 
* When all non-excluded backends have weight=0, GetNextEngine now elects one via WRR instead of returning nil, allowing zero-weight backends to serve as a failover tier. Redis shard-key affinity is not written in this case so the zero-weight selection is never persisted.