### PR TITLE
fix(client): avoid chunked transfer encoding for upstream requests

### DIFF
--- a/pkg/engines/client/http.go
+++ b/pkg/engines/client/http.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -129,16 +130,15 @@ func (e *HTTPEndpoint) Process(req *octollm.Request) (*octollm.Response, error) 
 		return nil, fmt.Errorf("parse request body error: %w", err)
 	}
 
-	bodyReader, err := req.Body.Reader()
+	bodyBytes, err := req.Body.Bytes()
 	if err != nil {
 		return nil, fmt.Errorf("get request body reader error: %w", err)
 	}
-	defer bodyReader.Close()
 	httpReq, err := http.NewRequestWithContext(
 		req.Context(),
 		http.MethodPost,
 		url,
-		bodyReader)
+		bytes.NewReader(bodyBytes))
 	if err != nil {
 		return nil, fmt.Errorf("new request error: %w", err)
 	}


### PR DESCRIPTION
Pass *bytes.Reader instead of io.NopCloser(io.Reader) to http.NewRequestWithContext so Go's HTTP client auto-detects ContentLength and omits Transfer-Encoding: chunked. Zero extra memory overhead since Body.Bytes() returns the already-cached slice.