### PR TITLE
feat: OpenAI Responses API (POST /v1/responses)

### DIFF
--- a/cmd/octollm-server/main.go
+++ b/cmd/octollm-server/main.go
@@ -103,6 +103,7 @@ func main() {
 	r.POST("/v1/messages", s.MessagesHandler())
 	r.POST("/v1/embeddings", s.EmbeddingsHandler())
 	r.POST("/v1/rerank", s.RerankHandler())
+	r.POST("/v1/responses", s.ResponsesHandler())
 	// Vertex AI / Gemini API endpoints
 	// modelName includes the action suffix (e.g., "gemini-2.0-flash:generateContent")
 	// This matches Google's API format where the action is part of the model identifier

--- a/cmd/octollm-server/server.go
+++ b/cmd/octollm-server/server.go
@@ -99,6 +99,17 @@ func (s *Server) RerankHandler() gin.HandlerFunc {
 	}
 }
 
+func (s *Server) ResponsesHandler() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		orgName := c.GetString("org")
+		userName := c.GetString("user")
+
+		engine := s.ruleComposer.GetEngine(userName, orgName, "")
+		handler := octollm.ResponsesHandler(engine)
+		handler(c.Writer, c.Request)
+	}
+}
+
 func (s *Server) VertexAIHandler() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		orgName := c.GetString("org")

--- a/examples/config-responses.yaml
+++ b/examples/config-responses.yaml
@@ -1,0 +1,8 @@
+# Example: OpenAI Responses API (gateway route POST /v1/responses → upstream POST .../v1/responses)
+models:
+  gpt-5.2:
+    backends:
+      default:1:
+        base_url: https://api.shubiaobiao.com
+        url_path_responses: /v1/responses
+        # api_key: sk-xxxx

--- a/pkg/composer/config_file.go
+++ b/pkg/composer/config_file.go
@@ -56,6 +56,7 @@ type Backend struct {
 	URLPathVertex           *string           `json:"url_path_vertex" yaml:"url_path_vertex"`
 	URLPathEmbedding        *string           `json:"url_path_embedding" yaml:"url_path_embedding"`
 	URLPathRerank           *string           `json:"url_path_rerank" yaml:"url_path_rerank"`
+	URLPathResponses        *string           `json:"url_path_responses" yaml:"url_path_responses"`
 	RequestCompression      string            `json:"request_compression" yaml:"request_compression"` // "gzip" or empty for no compression
 
 	ConvertToChat     string `json:"convert_to_chat" yaml:"convert_to_chat"`         // "from_messages" or "from_vertex"

--- a/pkg/composer/model_repo.go
+++ b/pkg/composer/model_repo.go
@@ -118,6 +118,9 @@ func (m *ModelRepoFileBased) UpdateFromConfig(conf *ConfigFile) error {
 			if backend.URLPathRerank != nil {
 				finalBackend.URLPathRerank = backend.URLPathRerank
 			}
+			if backend.URLPathResponses != nil {
+				finalBackend.URLPathResponses = backend.URLPathResponses
+			}
 			if backend.RequestCompression != "" {
 				finalBackend.RequestCompression = backend.RequestCompression
 			}
@@ -247,6 +250,13 @@ func (m *ModelRepoFileBased) BuildEngineByBackend(b *Backend) (octollm.Engine, e
 	} else {
 		generalConf.Endpoints[octollm.APIFormatRerank] = "" // will use default
 	}
+	if b.URLPathResponses != nil {
+		if *b.URLPathResponses != "" {
+			generalConf.Endpoints[octollm.APIFormatResponses] = *b.URLPathResponses
+		}
+	} else {
+		generalConf.Endpoints[octollm.APIFormatResponses] = "" // will use default
+	}
 	if b.URLPathVertex != nil {
 		if *b.URLPathVertex != "" {
 			generalConf.Endpoints[octollm.APIFormatGoogleGenerateContent] = *b.URLPathVertex
@@ -255,7 +265,7 @@ func (m *ModelRepoFileBased) BuildEngineByBackend(b *Backend) (octollm.Engine, e
 		generalConf.Endpoints[octollm.APIFormatGoogleGenerateContent] = "" // will use default
 	}
 	if len(generalConf.Endpoints) == 0 {
-		return nil, fmt.Errorf("backend must specify at least one URL path (chat, messages, vertex, embedding, or rerank)")
+		return nil, fmt.Errorf("backend must specify at least one URL path (chat, messages, vertex, embedding, rerank, or responses)")
 	}
 	if b.RequestCompression != "" {
 		generalConf.RequestCompression = b.RequestCompression

--- a/pkg/composer/rule_composer.go
+++ b/pkg/composer/rule_composer.go
@@ -275,6 +275,10 @@ func checkIsStream(req *octollm.Request) (bool, error) {
 		}
 	case *openai.CompletionRequest:
 		return body.Stream, nil
+	case *openai.ResponsesRequest:
+		if body.Stream != nil && *body.Stream {
+			return true, nil
+		}
 	case *anthropic.ClaudeMessagesRequest:
 		if body.Stream != nil && *body.Stream {
 			return true, nil
@@ -301,6 +305,8 @@ func (r *RuleComposerEngine) Process(req *octollm.Request) (*octollm.Response, e
 			case *openai.CompletionRequest:
 				r.Model = body.Model
 			case *openai.EmbeddingRequest:
+				r.Model = body.Model
+			case *openai.ResponsesRequest:
 				r.Model = body.Model
 			case *rerank.RerankRequest:
 				r.Model = body.Model

--- a/pkg/engines/client/general.go
+++ b/pkg/engines/client/general.go
@@ -45,6 +45,7 @@ var DefaultURLPathClaudeMessages = "/v1/messages"
 var DefaultURLPathVertex = "v1/models/{modelNameWithAction}" // Path for Vertex AI, {modelNameWithAction} includes action (e.g., "gemini-2.0-flash:generateContent")
 var DefaultURLPathEmbeddings = "/v1/embeddings"
 var DefaultURLPathRerank = "/v1/rerank"
+var DefaultURLPathResponses = "/v1/responses"
 
 func NewGeneralEndpoint(conf GeneralEndpointConfig) *GeneralEndpoint {
 	apiKey := conf.APIKey
@@ -73,6 +74,8 @@ func NewGeneralEndpoint(conf GeneralEndpointConfig) *GeneralEndpoint {
 					endpoint = DefaultURLPathEmbeddings
 				case octollm.APIFormatRerank:
 					endpoint = DefaultURLPathRerank
+				case octollm.APIFormatResponses:
+					endpoint = DefaultURLPathResponses
 				default:
 					return "", fmt.Errorf("invalid format: %s", req.Format)
 				}
@@ -103,6 +106,8 @@ func NewGeneralEndpoint(conf GeneralEndpointConfig) *GeneralEndpoint {
 					return &octollm.JSONParser[openai.EmbeddingResponse]{}
 				case octollm.APIFormatRerank:
 					return &octollm.JSONParser[rerank.RerankResponse]{}
+				case octollm.APIFormatResponses:
+					return &octollm.JSONParser[openai.ResponsesResponse]{}
 				default:
 					return &octollm.JSONParser[json.RawMessage]{}
 				}
@@ -117,6 +122,8 @@ func NewGeneralEndpoint(conf GeneralEndpointConfig) *GeneralEndpoint {
 					return &octollm.JSONParser[anthropic.ClaudeMessagesStreamEvent]{}, StreamingTypeSSE
 				case octollm.APIFormatGoogleGenerateContent:
 					return &octollm.JSONParser[vertex.StreamGenerateContentResponse]{}, StreamingTypeJSON
+				case octollm.APIFormatResponses:
+					return &octollm.JSONParser[openai.ResponseStreamChunk]{}, StreamingTypeSSE
 				default:
 					return &octollm.JSONParser[json.RawMessage]{}, StreamingTypeSSE
 				}

--- a/pkg/engines/moderator/openai_adapter_test.go
+++ b/pkg/engines/moderator/openai_adapter_test.go
@@ -475,3 +475,70 @@ func TestOpenAIAdapter_ExtractTextFromMessage(t *testing.T) {
 		})
 	}
 }
+
+func TestUniversalAdapter_ResponsesFormat(t *testing.T) {
+	adapter := NewUniversalAdapterWithConfig("[stream blocked]", "[blocked]", "content_filter")
+
+	t.Run("extract text from responses request", func(t *testing.T) {
+		req := &openai.ResponsesRequest{
+			Model: "gpt-5.4",
+			Input: &openai.ResponsesInput{
+				Items: []*openai.ResponsesInputItem{
+					{
+						Role: "user",
+						Content: []*openai.ResponsesInputContentItem{
+							{Type: "input_text", Text: "hello responses"},
+						},
+					},
+				},
+			},
+		}
+		body := octollm.NewBodyFromBytes([]byte{}, &octollm.JSONParser[openai.ResponsesRequest]{})
+		body.SetParsed(req)
+
+		got, err := adapter.ExtractTextFromBody(context.Background(), body)
+		if err != nil {
+			t.Fatalf("ExtractTextFromBody() error = %v", err)
+		}
+		if string(got) != "hello responses" {
+			t.Fatalf("ExtractTextFromBody() = %q, want %q", string(got), "hello responses")
+		}
+	})
+
+	t.Run("get replacement for responses non-stream", func(t *testing.T) {
+		resp := &openai.ResponsesResponse{
+			Id: "resp_123",
+			Output: []*openai.ResponsesOutputItem{
+				{
+					Type: "message",
+					Role: "assistant",
+					Content: []*openai.ResponsesOutputContentItem{
+						{Type: "output_text", Text: "origin"},
+					},
+				},
+			},
+		}
+		body := octollm.NewBodyFromBytes([]byte{}, &octollm.JSONParser[openai.ResponsesResponse]{})
+		body.SetParsed(resp)
+
+		replaced := adapter.GetReplacementBody(context.Background(), body)
+		if replaced == nil {
+			t.Fatal("GetReplacementBody() returned nil")
+		}
+
+		parsed, err := replaced.Parsed()
+		if err != nil {
+			t.Fatalf("replacement Parsed() error = %v", err)
+		}
+		gotResp, ok := parsed.(*openai.ResponsesResponse)
+		if !ok {
+			t.Fatalf("replacement body type = %T, want *openai.ResponsesResponse", parsed)
+		}
+		if len(gotResp.Output) != 1 || len(gotResp.Output[0].Content) != 1 {
+			t.Fatalf("unexpected replacement output shape: %+v", gotResp.Output)
+		}
+		if gotResp.Output[0].Content[0].Text != "[blocked]" {
+			t.Fatalf("replacement text = %q, want %q", gotResp.Output[0].Content[0].Text, "[blocked]")
+		}
+	})
+}

--- a/pkg/engines/moderator/openai_response_adapter.go
+++ b/pkg/engines/moderator/openai_response_adapter.go
@@ -1,0 +1,176 @@
+package moderator
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/infinigence/octollm/pkg/octollm"
+	"github.com/infinigence/octollm/pkg/types/openai"
+)
+
+// OpenAIResponseAdapter extracts and replaces text for the OpenAI Responses API
+// (POST /v1/responses) request and response bodies.
+type OpenAIResponseAdapter struct {
+	ReplacementTextForStreaming    string
+	ReplacementTextForNonStreaming string
+}
+
+var _ TextModeratorAdapter = (*OpenAIResponseAdapter)(nil)
+
+func (a *OpenAIResponseAdapter) ExtractTextFromBody(ctx context.Context, body *octollm.UnifiedBody) ([]rune, error) {
+	parsed, err := body.Parsed()
+	if err != nil {
+		return nil, fmt.Errorf("parse body error: %w", err)
+	}
+	switch parsed := parsed.(type) {
+	case *openai.ResponsesRequest:
+		return a.extractTextFromResponsesRequest(ctx, parsed)
+	case *openai.ResponsesResponse:
+		return a.extractTextFromResponsesNonStreamResponse(ctx, parsed)
+	case *openai.ResponseStreamChunk:
+		return a.extractTextFromResponsesStreamChunk(ctx, parsed)
+	default:
+		return nil, fmt.Errorf("unsupported body type: %T", parsed)
+	}
+}
+
+func (a *OpenAIResponseAdapter) GetReplacementBody(ctx context.Context, body *octollm.UnifiedBody) *octollm.UnifiedBody {
+	parsed, err := body.Parsed()
+	if err != nil {
+		slog.DebugContext(ctx, fmt.Sprintf("parse body error: %s", err))
+		return nil
+	}
+	switch parsed := parsed.(type) {
+	case *openai.ResponsesResponse:
+		r := a.getReplacementResponsesNonStreamResponse(ctx, parsed)
+		if r == nil {
+			return nil
+		}
+		body.SetParsed(r)
+		return body
+	case *openai.ResponseStreamChunk:
+		r := a.getReplacementResponsesStreamResponse(ctx, parsed)
+		if r == nil {
+			return nil
+		}
+		body.SetParsed(r)
+		return body
+	default:
+		return nil
+	}
+}
+
+func (a *OpenAIResponseAdapter) extractTextFromResponsesRequest(ctx context.Context, body *openai.ResponsesRequest) ([]rune, error) {
+	if body.Input == nil {
+		return []rune{}, nil
+	}
+	return []rune(body.Input.ExtractText()), nil
+}
+
+func (a *OpenAIResponseAdapter) extractTextFromResponsesNonStreamResponse(ctx context.Context, body *openai.ResponsesResponse) ([]rune, error) {
+	r := []rune{}
+	for _, outputItem := range body.Output {
+		if outputItem == nil {
+			continue
+		}
+		r = append(r, []rune(outputItem.ExtractText())...)
+	}
+	return r, nil
+}
+
+func (a *OpenAIResponseAdapter) extractTextFromResponsesStreamChunk(ctx context.Context, body *openai.ResponseStreamChunk) ([]rune, error) {
+	switch body.Type {
+	case "response.output_text.delta":
+		return []rune(body.Delta), nil
+	case "response.output_text.done":
+		return []rune(body.Text), nil
+	case "response.content_part.added", "response.content_part.done":
+		if body.Part == nil {
+			return []rune{}, nil
+		}
+		return []rune(body.Part.ExtractText()), nil
+	case "response.output_item.added", "response.output_item.done":
+		if body.Item == nil {
+			return []rune{}, nil
+		}
+		return []rune(body.Item.ExtractText()), nil
+	case "response.completed":
+		if body.Response == nil {
+			return []rune{}, nil
+		}
+		return a.extractTextFromResponsesNonStreamResponse(ctx, body.Response)
+	default:
+		return []rune{}, nil
+	}
+}
+
+func (a *OpenAIResponseAdapter) getReplacementResponsesNonStreamResponse(ctx context.Context, resp *openai.ResponsesResponse) *openai.ResponsesResponse {
+	if a.ReplacementTextForNonStreaming == "" {
+		return nil
+	}
+
+	return &openai.ResponsesResponse{
+		Id: resp.Id,
+		Output: []*openai.ResponsesOutputItem{
+			{
+				Type: "message",
+				Role: "assistant",
+				Content: []*openai.ResponsesOutputContentItem{
+					{
+						Type: "output_text",
+						Text: a.ReplacementTextForNonStreaming,
+					},
+				},
+			},
+		},
+		Usage: resp.Usage,
+	}
+}
+
+func (a *OpenAIResponseAdapter) getReplacementResponsesStreamResponse(ctx context.Context, resp *openai.ResponseStreamChunk) *openai.ResponseStreamChunk {
+	if a.ReplacementTextForStreaming == "" {
+		return nil
+	}
+
+	switch resp.Type {
+	case "response.output_text.delta":
+		r := *resp
+		r.Delta = a.ReplacementTextForStreaming
+		return &r
+	case "response.output_text.done":
+		r := *resp
+		r.Text = a.ReplacementTextForStreaming
+		return &r
+	case "response.content_part.added", "response.content_part.done":
+		r := *resp
+		r.Part = &openai.ResponsesOutputContentItem{
+			Type: "output_text",
+			Text: a.ReplacementTextForStreaming,
+		}
+		return &r
+	case "response.output_item.added", "response.output_item.done":
+		r := *resp
+		r.Item = &openai.ResponsesOutputItem{
+			Type: "message",
+			Role: "assistant",
+			Content: []*openai.ResponsesOutputContentItem{
+				{
+					Type: "output_text",
+					Text: a.ReplacementTextForStreaming,
+				},
+			},
+		}
+		return &r
+	case "response.completed":
+		r := *resp
+		if resp.Response == nil {
+			r.Response = a.getReplacementResponsesNonStreamResponse(ctx, &openai.ResponsesResponse{})
+			return &r
+		}
+		r.Response = a.getReplacementResponsesNonStreamResponse(ctx, resp.Response)
+		return &r
+	default:
+		return nil
+	}
+}

--- a/pkg/engines/moderator/openai_response_adapter_test.go
+++ b/pkg/engines/moderator/openai_response_adapter_test.go
@@ -1,0 +1,276 @@
+package moderator
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/infinigence/octollm/pkg/octollm"
+	"github.com/infinigence/octollm/pkg/types/openai"
+)
+
+func TestOpenAIResponseAdapter_ExtractTextFromResponsesRequest(t *testing.T) {
+	adapter := &OpenAIResponseAdapter{}
+
+	tests := []struct {
+		name    string
+		raw     string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "input is string",
+			raw: `{
+				"model":"gpt-5.4",
+				"input":"Tell me a three sentence bedtime story about a unicorn."
+			}`,
+			want:    "Tell me a three sentence bedtime story about a unicorn.",
+			wantErr: false,
+		},
+		{
+			name: "input is array with text and image",
+			raw: `{
+				"model":"gpt-5.4",
+				"input":[
+					{
+						"role":"user",
+						"content":[
+							{"type":"input_text","text":"what is in this image?"},
+							{
+								"type":"input_image",
+								"image_url":"https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg"
+							}
+						]
+					}
+				]
+			}`,
+			want:    "what is in this image?https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var req openai.ResponsesRequest
+			if err := json.Unmarshal([]byte(tt.raw), &req); err != nil {
+				t.Fatalf("unmarshal responses request: %v", err)
+			}
+
+			body := octollm.NewBodyFromBytes([]byte{}, &octollm.JSONParser[openai.ResponsesRequest]{})
+			body.SetParsed(&req)
+
+			got, err := adapter.ExtractTextFromBody(context.Background(), body)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ExtractTextFromBody() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if string(got) != tt.want {
+				t.Errorf("ExtractTextFromBody() = %v, want %v", string(got), tt.want)
+			}
+		})
+	}
+}
+
+func TestOpenAIResponseAdapter_ExtractTextFromResponsesResponse(t *testing.T) {
+	adapter := &OpenAIResponseAdapter{}
+
+	resp := &openai.ResponsesResponse{
+		Id: "resp_123",
+		Output: []*openai.ResponsesOutputItem{
+			{
+				ID:   "msg_1",
+				Type: "message",
+				Role: "assistant",
+				Content: []*openai.ResponsesOutputContentItem{
+					{Type: "output_text", Text: "Hi there! "},
+					{Type: "output_text", Text: "How can I help?"},
+				},
+			},
+		},
+	}
+
+	body := octollm.NewBodyFromBytes([]byte{}, &octollm.JSONParser[openai.ResponsesResponse]{})
+	body.SetParsed(resp)
+
+	got, err := adapter.ExtractTextFromBody(context.Background(), body)
+	if err != nil {
+		t.Fatalf("ExtractTextFromBody() error = %v", err)
+	}
+
+	want := "Hi there! How can I help?"
+	if string(got) != want {
+		t.Errorf("ExtractTextFromBody() = %v, want %v", string(got), want)
+	}
+}
+
+func TestOpenAIResponseAdapter_ExtractTextFromResponseStreamChunk(t *testing.T) {
+	adapter := &OpenAIResponseAdapter{}
+
+	tests := []struct {
+		name  string
+		chunk *openai.ResponseStreamChunk
+		want  string
+	}{
+		{
+			name: "output text delta",
+			chunk: &openai.ResponseStreamChunk{
+				Type:  "response.output_text.delta",
+				Delta: "Hi",
+			},
+			want: "Hi",
+		},
+		{
+			name: "output text done",
+			chunk: &openai.ResponseStreamChunk{
+				Type: "response.output_text.done",
+				Text: "Hi there!",
+			},
+			want: "Hi there!",
+		},
+		{
+			name: "content part done",
+			chunk: &openai.ResponseStreamChunk{
+				Type: "response.content_part.done",
+				Part: &openai.ResponsesOutputContentItem{
+					Type: "output_text",
+					Text: "Part text",
+				},
+			},
+			want: "Part text",
+		},
+		{
+			name: "output item done",
+			chunk: &openai.ResponseStreamChunk{
+				Type: "response.output_item.done",
+				Item: &openai.ResponsesOutputItem{
+					Type: "message",
+					Content: []*openai.ResponsesOutputContentItem{
+						{Type: "output_text", Text: "Item text"},
+					},
+				},
+			},
+			want: "Item text",
+		},
+		{
+			name: "response completed",
+			chunk: &openai.ResponseStreamChunk{
+				Type: "response.completed",
+				Response: &openai.ResponsesResponse{
+					Output: []*openai.ResponsesOutputItem{
+						{
+							Type: "message",
+							Content: []*openai.ResponsesOutputContentItem{
+								{Type: "output_text", Text: "Final text"},
+							},
+						},
+					},
+				},
+			},
+			want: "Final text",
+		},
+		{
+			name: "non text event",
+			chunk: &openai.ResponseStreamChunk{
+				Type: "response.created",
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := octollm.NewBodyFromBytes([]byte{}, &octollm.JSONParser[openai.ResponseStreamChunk]{})
+			body.SetParsed(tt.chunk)
+
+			got, err := adapter.ExtractTextFromBody(context.Background(), body)
+			if err != nil {
+				t.Fatalf("ExtractTextFromBody() error = %v", err)
+			}
+			if string(got) != tt.want {
+				t.Errorf("ExtractTextFromBody() = %v, want %v", string(got), tt.want)
+			}
+		})
+	}
+}
+
+func TestOpenAIResponseAdapter_GetReplacementBody_ResponsesNonStreaming(t *testing.T) {
+	adapter := &OpenAIResponseAdapter{
+		ReplacementTextForNonStreaming: "[Blocked by moderator]",
+	}
+
+	originalResp := &openai.ResponsesResponse{
+		Id: "resp_1",
+		Output: []*openai.ResponsesOutputItem{
+			{
+				Type: "message",
+				Role: "assistant",
+				Content: []*openai.ResponsesOutputContentItem{
+					{Type: "output_text", Text: "Original text"},
+				},
+			},
+		},
+		Usage: &openai.ResponsesUsage{TotalTokens: 10},
+	}
+
+	body := octollm.NewBodyFromBytes([]byte{}, &octollm.JSONParser[openai.ResponsesResponse]{})
+	body.SetParsed(originalResp)
+
+	replacementBody := adapter.GetReplacementBody(context.Background(), body)
+	if replacementBody == nil {
+		t.Fatal("GetReplacementBody() returned nil")
+	}
+
+	parsed, err := replacementBody.Parsed()
+	if err != nil {
+		t.Fatalf("Failed to parse replacement body: %v", err)
+	}
+
+	replacement := parsed.(*openai.ResponsesResponse)
+	if replacement.Id != "resp_1" {
+		t.Fatalf("Id = %q, want resp_1", replacement.Id)
+	}
+	if len(replacement.Output) != 1 || len(replacement.Output[0].Content) != 1 {
+		t.Fatalf("unexpected replacement output shape: %+v", replacement.Output)
+	}
+	if replacement.Output[0].Content[0].Type != "output_text" {
+		t.Fatalf("content type = %q, want output_text", replacement.Output[0].Content[0].Type)
+	}
+	if replacement.Output[0].Content[0].Text != "[Blocked by moderator]" {
+		t.Fatalf("content text = %q, want [Blocked by moderator]", replacement.Output[0].Content[0].Text)
+	}
+	if replacement.Usage == nil || replacement.Usage.TotalTokens != 10 {
+		t.Fatalf("usage should be preserved, got %+v", replacement.Usage)
+	}
+}
+
+func TestOpenAIResponseAdapter_GetReplacementBody_ResponsesStreaming(t *testing.T) {
+	adapter := &OpenAIResponseAdapter{
+		ReplacementTextForStreaming: "[Blocked stream]",
+	}
+
+	originalChunk := &openai.ResponseStreamChunk{
+		Type: "response.output_text.done",
+		Text: "Original stream text",
+	}
+
+	body := octollm.NewBodyFromBytes([]byte{}, &octollm.JSONParser[openai.ResponseStreamChunk]{})
+	body.SetParsed(originalChunk)
+
+	replacementBody := adapter.GetReplacementBody(context.Background(), body)
+	if replacementBody == nil {
+		t.Fatal("GetReplacementBody() returned nil")
+	}
+
+	parsed, err := replacementBody.Parsed()
+	if err != nil {
+		t.Fatalf("Failed to parse replacement body: %v", err)
+	}
+
+	replacement := parsed.(*openai.ResponseStreamChunk)
+	if replacement.Type != "response.output_text.done" {
+		t.Fatalf("type = %q, want response.output_text.done", replacement.Type)
+	}
+	if replacement.Text != "[Blocked stream]" {
+		t.Fatalf("text = %q, want [Blocked stream]", replacement.Text)
+	}
+}

--- a/pkg/engines/moderator/universal_adapter.go
+++ b/pkg/engines/moderator/universal_adapter.go
@@ -11,8 +11,9 @@ import (
 
 // UniversalAdapter 通用适配器，根据 Response 格式自动选择对应的 adapter
 type UniversalAdapter struct {
-	openaiAdapter *OpenAIAdapter
-	claudeAdapter *ClaudeAdapter
+	openaiAdapter          *OpenAIAdapter
+	openaiResponsesAdapter *OpenAIResponseAdapter
+	claudeAdapter          *ClaudeAdapter
 }
 
 var _ TextModeratorAdapter = (*UniversalAdapter)(nil)
@@ -20,8 +21,9 @@ var _ TextModeratorAdapter = (*UniversalAdapter)(nil)
 // NewUniversalAdapter 创建通用适配器
 func NewUniversalAdapter() *UniversalAdapter {
 	return &UniversalAdapter{
-		openaiAdapter: &OpenAIAdapter{},
-		claudeAdapter: &ClaudeAdapter{},
+		openaiAdapter:          &OpenAIAdapter{},
+		openaiResponsesAdapter: &OpenAIResponseAdapter{},
+		claudeAdapter:          &ClaudeAdapter{},
 	}
 }
 
@@ -36,6 +38,10 @@ func NewUniversalAdapterWithConfig(
 			ReplacementTextForStreaming:    replacementTextForStreaming,
 			ReplacementTextForNonStreaming: replacementTextForNonStreaming,
 			ReplacementFinishReason:        replacementFinishReason,
+		},
+		openaiResponsesAdapter: &OpenAIResponseAdapter{
+			ReplacementTextForStreaming:    replacementTextForStreaming,
+			ReplacementTextForNonStreaming: replacementTextForNonStreaming,
 		},
 		claudeAdapter: &ClaudeAdapter{
 			ReplacementTextForStreaming:    replacementTextForStreaming,
@@ -54,6 +60,8 @@ func (a *UniversalAdapter) ExtractTextFromBody(ctx context.Context, body *octoll
 
 	// 根据类型选择对应的 adapter
 	switch parsed.(type) {
+	case *openai.ResponsesRequest, *openai.ResponsesResponse, *openai.ResponseStreamChunk:
+		return a.openaiResponsesAdapter.ExtractTextFromBody(ctx, body)
 	case *openai.ChatCompletionRequest, *openai.ChatCompletionResponse, *openai.ChatCompletionStreamChunk:
 		return a.openaiAdapter.ExtractTextFromBody(ctx, body)
 	case *anthropic.ClaudeMessagesRequest, *anthropic.ClaudeMessagesResponse, *anthropic.ClaudeMessagesStreamEvent:
@@ -72,6 +80,8 @@ func (a *UniversalAdapter) GetReplacementBody(ctx context.Context, body *octollm
 
 	// 根据类型选择对应的 adapter
 	switch parsed.(type) {
+	case *openai.ResponsesResponse, *openai.ResponseStreamChunk:
+		return a.openaiResponsesAdapter.GetReplacementBody(ctx, body)
 	case *openai.ChatCompletionResponse, *openai.ChatCompletionStreamChunk:
 		return a.openaiAdapter.GetReplacementBody(ctx, body)
 	case *anthropic.ClaudeMessagesResponse, *anthropic.ClaudeMessagesStreamEvent:

--- a/pkg/octollm/handler.go
+++ b/pkg/octollm/handler.go
@@ -209,6 +209,11 @@ func RerankHandler(engine Engine) http.HandlerFunc {
 	return httpSSEHandler(engine, APIFormatRerank, &JSONParser[rerank.RerankRequest]{})
 }
 
+// ResponsesHandler handles OpenAI /v1/responses (Responses API) requests.
+func ResponsesHandler(engine Engine) http.HandlerFunc {
+	return httpSSEHandler(engine, APIFormatResponses, &JSONParser[openai.ResponsesRequest]{})
+}
+
 // httpJSONArrayHandler handles HTTP requests with given engine.
 // It is like httpSSEHandler, but if the engine returns a stream channel, it will write the response as a streamed JSON array.
 // This is the format used by Google Vertex AI API.

--- a/pkg/octollm/request.go
+++ b/pkg/octollm/request.go
@@ -20,6 +20,7 @@ const (
 	APIFormatGoogleGenerateContent APIFormat = "generateContent"
 	APIFormatEmbeddings            APIFormat = "embeddings"
 	APIFormatRerank                APIFormat = "rerank"
+	APIFormatResponses             APIFormat = "responses"
 )
 
 // Parser parses and serializes body of requests or responses.

--- a/pkg/types/openai/responses_req.go
+++ b/pkg/types/openai/responses_req.go
@@ -1,0 +1,154 @@
+package openai
+
+import "encoding/json"
+
+// ResponsesRequest is a minimal view of POST /v1/responses for routing and moderation.
+// Other JSON keys are ignored on unmarshal; callers forwarding unmodified bodies should
+// rely on octollm.UnifiedBody raw bytes.
+type ResponsesRequest struct {
+	Model  string          `json:"model,omitempty"`
+	Stream *bool           `json:"stream,omitempty"`
+	Input  *ResponsesInput `json:"input,omitempty"`
+}
+
+// ResponsesInput supports OpenAI Responses `input` polymorphism:
+// - string
+// - array of message-like input items
+type ResponsesInput struct {
+	String *string
+	Items  []*ResponsesInputItem
+}
+
+func (r *ResponsesInput) UnmarshalJSON(data []byte) error {
+	*r = ResponsesInput{}
+
+	if string(data) == "null" || len(data) == 0 {
+		return nil
+	}
+
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		r.String = &s
+		return nil
+	}
+
+	var items []*ResponsesInputItem
+	if err := json.Unmarshal(data, &items); err != nil {
+		return err
+	}
+	r.Items = items
+	return nil
+}
+
+func (r ResponsesInput) MarshalJSON() ([]byte, error) {
+	if r.String != nil {
+		return json.Marshal(*r.String)
+	}
+	return json.Marshal(r.Items)
+}
+
+func (r ResponsesInput) ExtractText() string {
+	if r.String != nil {
+		return *r.String
+	}
+
+	text := ""
+	for _, item := range r.Items {
+		if item == nil {
+			continue
+		}
+		text += item.ExtractText()
+	}
+	return text
+}
+
+type ResponsesInputItem struct {
+	Role    string                       `json:"role,omitempty"`
+	Content []*ResponsesInputContentItem `json:"content,omitempty"`
+}
+
+func (i *ResponsesInputItem) ExtractText() string {
+	if i == nil {
+		return ""
+	}
+
+	text := ""
+	for _, part := range i.Content {
+		if part == nil {
+			continue
+		}
+		text += part.ExtractText()
+	}
+	return text
+}
+
+type ResponsesInputContentItem struct {
+	Type     string          `json:"type"`
+	Text     string          `json:"text,omitempty"`
+	ImageURL ImageURLContent `json:"image_url,omitempty"`
+}
+
+func (i *ResponsesInputContentItem) UnmarshalJSON(data []byte) error {
+	type Alias struct {
+		Type     string          `json:"type"`
+		Text     string          `json:"text,omitempty"`
+		ImageURL json.RawMessage `json:"image_url,omitempty"`
+	}
+
+	var alias Alias
+	if err := json.Unmarshal(data, &alias); err != nil {
+		return err
+	}
+
+	i.Type = alias.Type
+	i.Text = alias.Text
+
+	if len(alias.ImageURL) > 0 {
+		imageURL, err := unmarshalImageURLContent(alias.ImageURL)
+		if err != nil {
+			return err
+		}
+		i.ImageURL = imageURL
+	}
+
+	return nil
+}
+
+func (i ResponsesInputContentItem) MarshalJSON() ([]byte, error) {
+	type Alias struct {
+		Type     string          `json:"type"`
+		Text     string          `json:"text,omitempty"`
+		ImageURL json.RawMessage `json:"image_url,omitempty"`
+	}
+
+	alias := Alias{
+		Type: i.Type,
+		Text: i.Text,
+	}
+
+	if i.ImageURL != nil {
+		imageURLBytes, err := json.Marshal(i.ImageURL)
+		if err != nil {
+			return nil, err
+		}
+		alias.ImageURL = imageURLBytes
+	}
+
+	return json.Marshal(alias)
+}
+
+func (i *ResponsesInputContentItem) ExtractText() string {
+	if i == nil {
+		return ""
+	}
+
+	switch i.Type {
+	case "input_text":
+		return i.Text
+	case "input_image":
+		if i.ImageURL != nil {
+			return i.ImageURL.GetImageUrl()
+		}
+	}
+	return ""
+}

--- a/pkg/types/openai/responses_req_test.go
+++ b/pkg/types/openai/responses_req_test.go
@@ -1,0 +1,96 @@
+package openai
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestResponsesRequest_UnmarshalJSON_ModelAndStream(t *testing.T) {
+	raw := `{"model":"gpt-4.1","stream":true,"input":[{"role":"user","content":[{"type":"input_text","text":"hi"}]}]}`
+	var req ResponsesRequest
+	if err := json.Unmarshal([]byte(raw), &req); err != nil {
+		t.Fatal(err)
+	}
+	if req.Model != "gpt-4.1" || req.Stream == nil || !*req.Stream {
+		t.Fatalf("%+v", req)
+	}
+	if req.Input == nil {
+		t.Fatal("input should not be nil")
+	}
+	if got := req.Input.ExtractText(); got != "hi" {
+		t.Fatalf("unexpected extracted input text: %q", got)
+	}
+}
+
+func TestResponsesRequest_Input_StringAndArray(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "input string",
+			raw:  `{"model":"gpt-5.4","input":"Tell me a three sentence bedtime story about a unicorn."}`,
+			want: "Tell me a three sentence bedtime story about a unicorn.",
+		},
+		{
+			name: "input array with text and image",
+			raw: `{"model":"gpt-5.4","input":[{"role":"user","content":[{"type":"input_text","text":"what is in this image?"},{"type":"input_image","image_url":"https://example.com/a.jpg"}]}]}`,
+			want: "what is in this image?https://example.com/a.jpg",
+		},
+		{
+			name: "input array with image object",
+			raw: `{"model":"gpt-5.4","input":[{"role":"user","content":[{"type":"input_image","image_url":{"url":"https://example.com/b.jpg","detail":"high"}}]}]}`,
+			want: "https://example.com/b.jpg",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var req ResponsesRequest
+			if err := json.Unmarshal([]byte(tt.raw), &req); err != nil {
+				t.Fatal(err)
+			}
+			if req.Input == nil {
+				t.Fatal("input should not be nil")
+			}
+			if got := req.Input.ExtractText(); got != tt.want {
+				t.Fatalf("ExtractText()=%q want=%q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResponsesResponse_UnmarshalJSON_Usage(t *testing.T) {
+	raw := `{
+		"id":"r1","object":"response","created_at":1,"status":"completed","model":"m",
+		"usage":{"input_tokens":10,"output_tokens":5,"total_tokens":15,
+			"input_tokens_details":{"cached_tokens":0},
+			"output_tokens_details":{"reasoning_tokens":0}
+		}
+	}`
+	var resp ResponsesResponse
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Usage == nil || resp.Usage.TotalTokens != 15 {
+		t.Fatal(resp.Usage)
+	}
+	if resp.Usage.InputTokensDetails == nil || resp.Usage.InputTokensDetails.CachedTokens != 0 {
+		t.Fatalf("input_tokens_details: %+v", resp.Usage.InputTokensDetails)
+	}
+	if resp.Usage.OutputTokensDetails == nil || resp.Usage.OutputTokensDetails.ReasoningTokens != 0 {
+		t.Fatalf("output_tokens_details: %+v", resp.Usage.OutputTokensDetails)
+	}
+}
+
+func TestResponseStreamChunk_UnmarshalJSON(t *testing.T) {
+	raw := `{"type":"response.completed","response":{"usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}}`
+	var ch ResponseStreamChunk
+	if err := json.Unmarshal([]byte(raw), &ch); err != nil {
+		t.Fatal(err)
+	}
+	if ch.Type != "response.completed" || ch.Response == nil || ch.Response.Usage == nil || ch.Response.Usage.TotalTokens != 3 {
+		t.Fatalf("%+v", ch.Response)
+	}
+}

--- a/pkg/types/openai/responses_resp.go
+++ b/pkg/types/openai/responses_resp.go
@@ -1,0 +1,94 @@
+package openai
+
+// ResponsesResponse is a minimal POST /v1/responses response object: only usage is typed
+// for gateway logic; other JSON keys are ignored on unmarshal.
+type ResponsesResponse struct {
+	Id     string                 `json:"id"`
+	Output []*ResponsesOutputItem `json:"output,omitempty"`
+	Usage  *ResponsesUsage        `json:"usage,omitempty"`
+}
+
+// ResponsesOutputItem is one item in Responses API `output` array.
+type ResponsesOutputItem struct {
+	ID      string                        `json:"id,omitempty"`
+	Type    string                        `json:"type,omitempty"`
+	Role    string                        `json:"role,omitempty"`
+	Content []*ResponsesOutputContentItem `json:"content,omitempty"`
+}
+
+func (i *ResponsesOutputItem) ExtractText() string {
+	if i == nil {
+		return ""
+	}
+
+	text := ""
+	for _, part := range i.Content {
+		if part == nil {
+			continue
+		}
+		text += part.ExtractText()
+	}
+	return text
+}
+
+// ResponsesOutputContentItem is one message content part inside Responses output.
+type ResponsesOutputContentItem struct {
+	Type    string `json:"type,omitempty"`
+	Text    string `json:"text,omitempty"`
+	Refusal string `json:"refusal,omitempty"`
+}
+
+func (i *ResponsesOutputContentItem) ExtractText() string {
+	if i == nil {
+		return ""
+	}
+
+	switch i.Type {
+	case "output_text":
+		return i.Text
+	case "refusal":
+		return i.Refusal
+	default:
+		return ""
+	}
+}
+
+// ResponsesUsage is token usage on completed responses (fixed OpenAI shape).
+type ResponsesUsage struct {
+	InputTokens  int `json:"input_tokens"`
+	OutputTokens int `json:"output_tokens"`
+	TotalTokens  int `json:"total_tokens"`
+
+	InputTokensDetails  *ResponsesInputTokenDetails  `json:"input_tokens_details,omitempty"`
+	OutputTokensDetails *ResponsesOutputTokenDetails `json:"output_tokens_details,omitempty"`
+}
+
+// ResponsesInputTokenDetails breaks down input tokens (e.g. prompt caching).
+type ResponsesInputTokenDetails struct {
+	CachedTokens int `json:"cached_tokens"`
+}
+
+// ResponsesOutputTokenDetails breaks down output tokens (e.g. reasoning).
+type ResponsesOutputTokenDetails struct {
+	ReasoningTokens int `json:"reasoning_tokens"`
+}
+
+// ResponseStreamChunk is one SSE JSON object from POST /v1/responses with stream=true.
+//
+// Reference: https://platform.openai.com/docs/api-reference/responses-streaming
+type ResponseStreamChunk struct {
+	Type string `json:"type"`
+
+	// response.output_text.delta
+	Delta string `json:"delta,omitempty"`
+	// response.output_text.done
+	Text string `json:"text,omitempty"`
+
+	// response.content_part.added / response.content_part.done
+	Part *ResponsesOutputContentItem `json:"part,omitempty"`
+	// response.output_item.added / response.output_item.done
+	Item *ResponsesOutputItem `json:"item,omitempty"`
+
+	// Lifecycle snapshots (response.created, response.in_progress, response.completed, …).
+	Response *ResponsesResponse `json:"response,omitempty"`
+}


### PR DESCRIPTION
Expose the Responses API on the gateway with the same HTTP/SSE pipeline as other OpenAI routes.

- Add route and ResponsesHandler; APIFormatResponses and request/response stream types
- Extend GeneralEndpoint and NewOpenAIResponsesEndpoint for upstream /v1/responses
- Support optional backend url_path_responses in YAML; wire model routing and stream detection
- Add example config and tests for Responses request JSON