### PR TITLE
fix(limiter): allow equal adjacent tiers in color rate filters

### DIFF
--- a/pkg/engines/limiter/concurrency_color_limiter.go
+++ b/pkg/engines/limiter/concurrency_color_limiter.go
@@ -32,7 +32,7 @@ var _ octollm.Engine = (*ConcurrencyColorLimiterEngine)(nil)
 // NewConcurrencyColorLimiterEngine creates a concurrency color limiter engine with priority-based limits
 // redisClient: Redis client
 // key: Redis key prefix for storing concurrency counts (each tier uses key:tier_N)
-// rates: Concurrency limit array for each priority tier (must be strictly decreasing), e.g., [200, 100, 50]
+// rates: Concurrency limit array for each priority tier (must be non-increasing), e.g., [200, 100, 50]
 //
 //	means tier 0 (priority 2): 200 concurrent, tier 1 (priority 1): 100 concurrent, tier 2 (priority 0): 50 concurrent
 //
@@ -78,7 +78,7 @@ func NewConcurrencyColorLimiterEngine(redisClient *redis.Client, key string, rat
 	}
 	filteredRates, filtered := filterDecreasingRates(rates)
 	if filtered {
-		slog.Warn(fmt.Sprintf("concurrency_rates must be strictly decreasing, filtered from %v to %v (removed %d non-decreasing values)", rates, filteredRates, len(rates)-len(filteredRates)))
+		slog.Warn(fmt.Sprintf("concurrency_rates must be non-increasing, filtered from %v to %v (removed %d invalid suffix values)", rates, filteredRates, len(rates)-len(filteredRates)))
 	}
 
 	return &ConcurrencyColorLimiterEngine{
@@ -282,7 +282,7 @@ func filterDecreasingRates(rates []int) ([]int, bool) {
 	filteredRates = append(filteredRates, rates[0])
 
 	for i := 1; i < len(rates); i++ {
-		if rates[i] < rates[i-1] {
+		if rates[i] <= rates[i-1] {
 			filteredRates = append(filteredRates, rates[i])
 		} else {
 			break

--- a/pkg/engines/limiter/concurrency_color_limiter_test.go
+++ b/pkg/engines/limiter/concurrency_color_limiter_test.go
@@ -34,21 +34,27 @@ func TestFilterDecreasingRates(t *testing.T) {
 			wantFiltered: false,
 		},
 		{
-			name:         "all_strictly_decreasing",
+			name:         "all_non_increasing",
 			in:           []int{100, 10, 5, 1},
 			wantOut:      []int{100, 10, 5, 1},
 			wantFiltered: false,
 		},
 		{
-			name:         "stops_on_non_decreasing",
+			name:         "stops_on_increase",
 			in:           []int{100, 50, 75, 10},
 			wantOut:      []int{100, 50},
 			wantFiltered: true,
 		},
 		{
-			name:         "stops_on_equal",
+			name:         "allows_equal_plateau",
 			in:           []int{5, 4, 4, 3},
-			wantOut:      []int{5, 4},
+			wantOut:      []int{5, 4, 4, 3},
+			wantFiltered: false,
+		},
+		{
+			name:         "stops_after_plateau_on_increase",
+			in:           []int{5, 4, 4, 5},
+			wantOut:      []int{5, 4, 4},
 			wantFiltered: true,
 		},
 		{
@@ -94,8 +100,8 @@ func TestNewConcurrencyColorLimiterEngine_ValidationAndFiltering(t *testing.T) {
 	_, err = NewConcurrencyColorLimiterEngine(nil, "k", []int{2, 1}, 0, "ns", next)
 	assert.Error(t, err)
 
-	// non-decreasing rates get filtered (stop at first violation)
-	e, err = NewConcurrencyColorLimiterEngine(nil, "k", []int{10, 5, 5, 1}, time.Second, "ns", next)
+	// rates that break non-increasing order get filtered (stop at first increase)
+	e, err = NewConcurrencyColorLimiterEngine(nil, "k", []int{10, 5, 6, 1}, time.Second, "ns", next)
 	assert.NoError(t, err)
 	assert.Equal(t, []int{10, 5}, e.concurrencyRates)
 }
@@ -145,6 +151,59 @@ func TestConcurrencyColorLimiter_PriorityMappingAndReservation(t *testing.T) {
 	assert.NoError(t, resp2.Body.Close())
 }
 
+// [3,3,3]: same numeric limits per tier; asserts p2 allows 3, p1 allows 2, p0 allows 1 (tier0 reservation still differs by priority).
+func TestConcurrencyColorLimiter_EqualTierLimits_ReservationCaps(t *testing.T) {
+	t.Parallel()
+	mr := miniredis.RunT(t)
+	defer mr.Close()
+
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	ns := "limiter-ns-eq333"
+	next := &nextNewBodyPerCallEngine{}
+	e, err := NewConcurrencyColorLimiterEngine(client, "limiter-key-eq333", []int{3, 3, 3}, 10*time.Second, ns, next)
+	assert.NoError(t, err)
+
+	p2 := 2
+	var held []*octollm.Response
+	for i := 0; i < 3; i++ {
+		resp, err := e.Process(newConcurrencyColorLimiterTestRequest(t, ns, &p2))
+		assert.NoError(t, err, "p2 request %d", i+1)
+		assert.NotNil(t, resp)
+		held = append(held, resp)
+	}
+	_, err = e.Process(newConcurrencyColorLimiterTestRequest(t, ns, &p2))
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrRateLimitReached)
+	for _, r := range held {
+		assert.NoError(t, r.Body.Close())
+	}
+	held = held[:0]
+
+	p1 := 1
+	for i := 0; i < 2; i++ {
+		resp, err := e.Process(newConcurrencyColorLimiterTestRequest(t, ns, &p1))
+		assert.NoError(t, err, "p1 request %d", i+1)
+		assert.NotNil(t, resp)
+		held = append(held, resp)
+	}
+	_, err = e.Process(newConcurrencyColorLimiterTestRequest(t, ns, &p1))
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrRateLimitReached)
+	for _, r := range held {
+		assert.NoError(t, r.Body.Close())
+	}
+	held = held[:0]
+
+	p0 := 0
+	resp, err := e.Process(newConcurrencyColorLimiterTestRequest(t, ns, &p0))
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	_, err = e.Process(newConcurrencyColorLimiterTestRequest(t, ns, &p0))
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrRateLimitReached)
+	assert.NoError(t, resp.Body.Close())
+}
+
 func TestConcurrencyColorLimiter_NoPriorityDefaultsToLowest(t *testing.T) {
 	t.Parallel()
 	mr := miniredis.RunT(t)
@@ -192,13 +251,13 @@ func TestConcurrencyColor_MarkerLimiterChain_MarkerBottleneck_Allows2ThenRejects
 	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
 	ns := "chain-ns"
 
-	// Marker tiers allow 1 max-priority at once, and share last tier with it (rates=[1,2]).
-	// Expected: request #1 -> priority 1 (occupies tier0+tier1), request #2 -> priority 0 (occupies tier1),
-	// request #3 -> rejected because marker tier1 is full.
-	markerRates := []int{1, 2}
+	// Marker: non-decreasing limits with a plateau ([1,1,2]) — three tiers, last tier cap 2.
+	// Expected: #1 -> highest priority (tiers 0+2), #2 -> middle tier + last (still within last cap),
+	// #3 -> rejected when all tiers / last tier are full.
+	markerRates := []int{1, 1, 2}
 
-	// Limiter should not be the bottleneck for this test.
-	limiterRates := []int{3, 2}
+	// Limiter: non-increasing with a plateau ([3,3,2]); generous enough not to bottleneck marker.
+	limiterRates := []int{3, 3, 2}
 
 	next := &nextNewBodyPerCallEngine{}
 	limiter, err := NewConcurrencyColorLimiterEngine(client, "chain-limiter", limiterRates, 10*time.Second, ns, next)
@@ -231,12 +290,12 @@ func TestConcurrencyColor_MarkerLimiterChain_LimiterBottleneck_Allows1ThenReject
 	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
 	ns := "chain-ns-2"
 
-	// Same marker as the previous test: request #2 becomes priority 0 after tier0 is full.
-	markerRates := []int{1, 2}
+	// Same marker shape as previous test but with equal low tiers ([1,1,2]).
+	markerRates := []int{1, 1, 2}
 
-	// Limiter reservation makes priority 0 require tier0Count < (tier0Limit-1).
-	// With tier0Limit=2 and after priority 1 held (tier0Count=1), priority 0 will be denied.
-	limiterRates := []int{2, 1}
+	// Limiter: plateau on high tiers ([2,2,1]); for the 2nd request (priority 1) reservedSlots=1
+	// requires tier0Count < tier0Limit-1, which fails once tier0 already holds the first request.
+	limiterRates := []int{2, 2, 1}
 
 	next := &nextNewBodyPerCallEngine{}
 	limiter, err := NewConcurrencyColorLimiterEngine(client, "chain-limiter-2", limiterRates, 10*time.Second, ns, next)

--- a/pkg/engines/limiter/concurrency_color_marker.go
+++ b/pkg/engines/limiter/concurrency_color_marker.go
@@ -29,7 +29,7 @@ var _ octollm.Engine = (*ConcurrencyColorMarkerEngine)(nil)
 // NewConcurrencyColorMarkerEngine creates a multi-tier concurrency-based marker with priority assignment
 // redisClient: Redis client
 // key: Redis key prefix for storing concurrency counts (each tier uses key:tier_N)
-// rates: Concurrency limit array for each priority tier (must be strictly increasing), e.g., [10, 50, 100]
+// rates: Concurrency limit array for each priority tier (must be non-decreasing), e.g., [10, 50, 100]
 //
 //	means tier 0 allows 10 concurrent, tier 1 allows 50 concurrent, tier 2 allows 100 concurrent
 //	Priority is calculated as: len(rates) - 1 - tierIdx
@@ -40,7 +40,7 @@ var _ octollm.Engine = (*ConcurrencyColorMarkerEngine)(nil)
 // next: Next engine
 //
 // Working principle:
-// - Each tier has its own concurrency limit (strictly increasing)
+// - Each tier has its own concurrency limit (non-decreasing)
 // - Priority number: larger = higher priority (priority 2 > priority 1 > priority 0)
 // - When a request comes in, it tries to acquire from tier 0 (smallest limit, highest priority) first
 // - Occupancy rule:
@@ -80,7 +80,7 @@ func NewConcurrencyColorMarkerEngine(redisClient *redis.Client, key string, rate
 
 	filteredRates, filtered := filterIncreasingRates(rates)
 	if filtered {
-		slog.Warn(fmt.Sprintf("rates must be strictly increasing, filtered from %v to %v (removed %d non-increasing values)", rates, filteredRates, len(rates)-len(filteredRates)))
+		slog.Warn(fmt.Sprintf("rates must be non-decreasing, filtered from %v to %v (removed %d invalid suffix values)", rates, filteredRates, len(rates)-len(filteredRates)))
 	}
 
 	return &ConcurrencyColorMarkerEngine{
@@ -227,7 +227,7 @@ func filterIncreasingRates(rates []int) ([]int, bool) {
 	filteredRates = append(filteredRates, rates[0])
 
 	for i := 1; i < len(rates); i++ {
-		if rates[i] > rates[i-1] {
+		if rates[i] >= rates[i-1] {
 			filteredRates = append(filteredRates, rates[i])
 		} else {
 			break

--- a/pkg/engines/limiter/concurrency_color_marker_test.go
+++ b/pkg/engines/limiter/concurrency_color_marker_test.go
@@ -34,21 +34,27 @@ func TestFilterIncreasingRates(t *testing.T) {
 			wantFiltered: false,
 		},
 		{
-			name:         "all_strictly_increasing",
+			name:         "all_non_decreasing",
 			in:           []int{1, 5, 10, 100},
 			wantOut:      []int{1, 5, 10, 100},
 			wantFiltered: false,
 		},
 		{
-			name:         "stops_on_non_increasing",
+			name:         "stops_on_decrease",
 			in:           []int{1, 5, 3, 10},
 			wantOut:      []int{1, 5},
 			wantFiltered: true,
 		},
 		{
-			name:         "stops_on_equal",
+			name:         "allows_equal_plateau",
 			in:           []int{1, 2, 2, 3},
-			wantOut:      []int{1, 2},
+			wantOut:      []int{1, 2, 2, 3},
+			wantFiltered: false,
+		},
+		{
+			name:         "stops_after_plateau_on_decrease",
+			in:           []int{1, 2, 2, 1},
+			wantOut:      []int{1, 2, 2},
 			wantFiltered: true,
 		},
 		{
@@ -112,7 +118,7 @@ func TestNewConcurrencyColorMarkerEngine_ValidationAndFiltering(t *testing.T) {
 	_, err = NewConcurrencyColorMarkerEngine(nil, "k", []int{1}, 0, "ns", next)
 	assert.Error(t, err)
 
-	// non-increasing rates get filtered (stop at first violation)
+	// rates that break non-decreasing order get filtered (stop at first decrease)
 	e, err = NewConcurrencyColorMarkerEngine(nil, "k", []int{1, 3, 2, 10}, time.Second, "ns", next)
 	assert.NoError(t, err)
 	assert.Equal(t, []int{1, 3}, e.rates)
@@ -161,5 +167,37 @@ func TestConcurrencyColorMarker_PriorityAssignmentAndExhaustion(t *testing.T) {
 	// cleanup: close bodies to trigger release and stop renew goroutines
 	assert.NoError(t, resp1.Body.Close())
 	assert.NoError(t, resp2.Body.Close())
+}
+
+// [3,3]: asserts every allowed request is colored priority 1, then the next is rejected when both tiers are full.
+func TestConcurrencyColorMarker_EqualTierLimits_AllPriority1(t *testing.T) {
+	t.Parallel()
+	mr := miniredis.RunT(t)
+	defer mr.Close()
+
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	ns := "marker-ns-eq33"
+	next := &priorityCaptureEngine{ns: ns}
+
+	e, err := NewConcurrencyColorMarkerEngine(client, "marker-key-eq33", []int{3, 3}, 10*time.Second, ns, next)
+	assert.NoError(t, err)
+
+	var resps []*octollm.Response
+	for i := 0; i < 3; i++ {
+		resp, err := e.Process(newConcurrencyColorMarkerTestRequest(t))
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+		assert.Equal(t, 1, next.lastPriority, "request %d should be colored priority 1", i+1)
+		resps = append(resps, resp)
+	}
+
+	_, err = e.Process(newConcurrencyColorMarkerTestRequest(t))
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrRateLimitReached)
+	assert.Equal(t, 3, next.callCount, "denied request must not reach next")
+
+	for _, r := range resps {
+		assert.NoError(t, r.Body.Close())
+	}
 }
 

--- a/pkg/engines/limiter/request_color_limiter.go
+++ b/pkg/engines/limiter/request_color_limiter.go
@@ -18,7 +18,7 @@ import (
 type RequestColorLimiterEngine struct {
 	redisClient           *redis.Client
 	keyPrefix             string        // Redis key prefix for storing token bucket states
-	limits                []int         // Request limits for each supported priority tier (must be strictly decreasing)
+	limits                []int         // Request limits for each supported priority tier (must be non-increasing)
 	rates                 []float64     // Token refill rates for each priority tier (calculated from limits and window)
 	ttls                  []int64       // Redis key TTL in seconds per tier; when expired, bucket is guaranteed full
 	window                time.Duration // Time window
@@ -35,7 +35,7 @@ var ErrRequestLimitReached = errors.New("request limit reached")
 // NewRequestColorLimiterEngine creates a multi-tier token bucket-based priority rate limiter
 // redisClient: Redis client
 // keyPrefix: Redis key prefix for storing token bucket states (each tier uses keyPrefix:tier_N)
-// limits: Request limit array for each supported priority tier (must be strictly decreasing), e.g., [200, 100, 50]
+// limits: Request limit array for each supported priority tier (must be non-increasing), e.g., [200, 100, 50]
 //
 //	means this limiter supports priority 2, 1, 0
 //	tier 0 (priority 2): 200 requests, tier 1 (priority 1): 100 requests, tier 2 (priority 0): 50 requests within the window
@@ -93,10 +93,10 @@ func NewRequestColorLimiterEngine(redisClient *redis.Client, keyPrefix string, l
 		}, nil
 	}
 
-	// Validate and filter limits to ensure strictly decreasing order
+	// Validate and filter limits to ensure non-increasing order
 	filteredLimits, filtered := filterDecreasingRates(limits)
 	if filtered {
-		slog.Warn(fmt.Sprintf("request_color_limiter_limits must be strictly decreasing, filtered from %v to %v (removed %d non-decreasing values)", limits, filteredLimits, len(limits)-len(filteredLimits)))
+		slog.Warn(fmt.Sprintf("request_color_limiter_limits must be non-increasing, filtered from %v to %v (removed %d invalid suffix values)", limits, filteredLimits, len(limits)-len(filteredLimits)))
 	}
 
 	if window <= 0 {

--- a/pkg/engines/limiter/request_color_marker.go
+++ b/pkg/engines/limiter/request_color_marker.go
@@ -17,7 +17,7 @@ import (
 type RequestColorMarkerEngine struct {
 	redisClient       *redis.Client
 	keyPrefix         string        // Redis key prefix for storing token bucket states
-	limits            []int         // Request limits for each priority tier (must be strictly increasing)
+	limits            []int         // Request limits for each priority tier (must be non-decreasing)
 	rates             []float64     // Token refill rates for each priority tier (calculated from limits and window)
 	ttls              []int64       // Redis key TTL in seconds per tier; when expired, bucket is guaranteed full
 	window            time.Duration // Time window
@@ -31,7 +31,7 @@ var _ octollm.Engine = (*RequestColorMarkerEngine)(nil)
 // NewRequestColorMarkerEngine creates a multi-tier token bucket-based request rate limiter with priority marking
 // redisClient: Redis client
 // keyPrefix: Redis key prefix for storing token bucket states (each tier uses keyPrefix:tier_N)
-// limits: Request limit array for each priority tier (must be strictly increasing), e.g., [10, 50, 100]
+// limits: Request limit array for each priority tier (must be non-decreasing), e.g., [10, 50, 100]
 //
 //	means tier 0 allows 10 requests, tier 1 allows 50 requests, tier 2 allows 100 requests within the window
 //	Priority is calculated as: len(limits) - 1 - tierIdx
@@ -81,10 +81,10 @@ func NewRequestColorMarkerEngine(redisClient *redis.Client, keyPrefix string, li
 		}, nil
 	}
 
-	// Validate and filter limits to ensure strictly increasing order
+	// Validate and filter limits to ensure non-decreasing order
 	filteredLimits, filtered := filterIncreasingRates(limits)
 	if filtered {
-		slog.Warn(fmt.Sprintf("request_color_marker_limits must be strictly increasing, filtered from %v to %v (removed %d non-increasing values)", limits, filteredLimits, len(limits)-len(filteredLimits)))
+		slog.Warn(fmt.Sprintf("request_color_marker_limits must be non-decreasing, filtered from %v to %v (removed %d invalid suffix values)", limits, filteredLimits, len(limits)-len(filteredLimits)))
 	}
 
 	if window <= 0 {


### PR DESCRIPTION
filterDecreasingRates and filterIncreasingRates now accept non-increasing and non-decreasing sequences respectively (plateaus allowed). Update docs, warn logs, and tests; request_color engines share the same helpers.