### PR TITLE
feat(converter,rule-engine): drop x-anthropic-billing-head from system prompt handling

### DIFF
--- a/pkg/engines/converter/claude.go
+++ b/pkg/engines/converter/claude.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/infinigence/octollm/pkg/octollm"
 	"github.com/infinigence/octollm/pkg/types/anthropic"
@@ -126,7 +127,10 @@ func (e *ChatCompletionToClaudeMessages) convertRequestBody(ctx context.Context,
 				Content: openai.MessageContentString(sys),
 			})
 		case anthropic.SystemBlocks:
-			for _, block := range sys {
+			for i, block := range sys {
+				if i == 0 && strings.HasPrefix(block.Text, "x-anthropic-billing-header:") {
+					continue
+				}
 				messages = append(messages, &openai.Message{
 					Role:    anthropic.MessageParamRoleSystem,
 					Content: openai.MessageContentString(block.Text),
@@ -161,21 +165,21 @@ func (e *ChatCompletionToClaudeMessages) convertRequestBody(ctx context.Context,
 							Text: *contentBlock.Text,
 						})
 					}
-			case anthropic.MessageContentImageType:
-				if contentBlock.Source != nil {
-					url := ""
-					if contentBlock.Source.Type == "base64" && len(contentBlock.Source.Data) > 0 {
-						mediaType := "image/jpeg"
-						if contentBlock.Source.MediaType != "" {
-							mediaType = contentBlock.Source.MediaType
+				case anthropic.MessageContentImageType:
+					if contentBlock.Source != nil {
+						url := ""
+						if contentBlock.Source.Type == "base64" && len(contentBlock.Source.Data) > 0 {
+							mediaType := "image/jpeg"
+							if contentBlock.Source.MediaType != "" {
+								mediaType = contentBlock.Source.MediaType
+							}
+							var dataStr string
+							if err := json.Unmarshal(contentBlock.Source.Data, &dataStr); err == nil {
+								url = fmt.Sprintf("data:%s;base64,%s", mediaType, dataStr)
+							}
+						} else if contentBlock.Source.Type == "url" {
+							url = contentBlock.Source.Url
 						}
-						var dataStr string
-						if err := json.Unmarshal(contentBlock.Source.Data, &dataStr); err == nil {
-							url = fmt.Sprintf("data:%s;base64,%s", mediaType, dataStr)
-						}
-					} else if contentBlock.Source.Type == "url" {
-						url = contentBlock.Source.Url
-					}
 						contentParts = append(contentParts, &openai.MessageContentItem{
 							Type: "image_url",
 							ImageURL: &openai.MessageContentItemImageURL{

--- a/pkg/engines/converter/claude_test.go
+++ b/pkg/engines/converter/claude_test.go
@@ -262,6 +262,47 @@ func TestChatCompletionsToClaudeMessages_convertRequestBody_MultipleSystem(t *te
 
 	testChatCompletionsToClaudeMessages_convertRequestBody(t, claudeReqJSON, expectedOpenaiReqJSON)
 }
+
+func TestChatCompletionsToClaudeMessages_convertRequestBody_IgnoreAnthropicBillingHeader(t *testing.T) {
+	claudeReqJSON := `{
+		"model": "claude-3-5-haiku",
+		"max_tokens": 1024,
+		"system": [
+			{
+				"type": "text",
+				"text": "x-anthropic-billing-header: cc_version=2.1.117.e85; cc_entrypoint=cli; cch=00000;"
+			},
+			{
+				"type": "text",
+				"text": "You are Claude Code, Anthropic's official CLI for Claude."
+			}
+		],
+		"messages": [
+			{
+				"role": "user",
+				"content": "Hello, how are you?"
+			}
+		]
+	}`
+
+	expectedOpenaiReqJSON := `{
+		"model": "claude-3-5-haiku",
+		"max_tokens": 1024,
+		"messages": [
+			{
+				"role": "system",
+				"content": "You are Claude Code, Anthropic's official CLI for Claude."
+			},
+			{
+				"role": "user",
+				"content": [{ "type": "text", "text": "Hello, how are you?" }]
+			}
+		]
+	}`
+
+	testChatCompletionsToClaudeMessages_convertRequestBody(t, claudeReqJSON, expectedOpenaiReqJSON)
+}
+
 func TestChatCompletionsToClaudeMessages_convertRequestBody_MultipleText(t *testing.T) {
 	claudeReqJSON := `{
 		"model": "claude-3-5-haiku",

--- a/pkg/engines/rule-engine/simple_features.go
+++ b/pkg/engines/rule-engine/simple_features.go
@@ -27,28 +27,35 @@ func combinedTextForAnthropicMessage(msg *anthropic.MessageParam) string {
 	return sb.String()
 }
 
+func checkIsAnthropicBillingHead(text string) bool {
+	return strings.HasPrefix(text, "x-anthropic-billing-header:")
+}
+
 // anthropicSystemText extracts plain text from a system field (SystemString or SystemBlocks).
-func anthropicSystemText(system anthropic.SystemContent) string {
+func anthropicSystemText(system anthropic.SystemContent) []string {
 	if system == nil {
-		return ""
+		return nil
 	}
 	switch s := system.(type) {
 	case anthropic.SystemString:
-		return string(s)
+		return []string{string(s)}
 	case anthropic.SystemBlocks:
-		var sb strings.Builder
-		for _, b := range s {
-			sb.WriteString(b.Text)
+		var res []string
+		for i, b := range s {
+			if i == 0 && checkIsAnthropicBillingHead(b.Text) {
+				continue
+			}
+			res = append(res, b.Text)
 		}
-		return sb.String()
+		return res
 	}
-	return ""
+	return nil
 }
 
 // anthropicFirstMessageText returns the text of the "first message" in an Anthropic request,
 // treating the system prompt as the first entry (matching converter behaviour).
 func anthropicFirstMessageText(v *anthropic.ClaudeMessagesRequest) string {
-	if sysTxt := strings.TrimSpace(anthropicSystemText(v.System)); sysTxt != "" {
+	if sysTxt := strings.TrimSpace(strings.Join(anthropicSystemText(v.System), "")); sysTxt != "" {
 		return sysTxt
 	}
 	if len(v.Messages) > 0 {
@@ -92,7 +99,10 @@ func computeAnthropicMessage5Hashes(system anthropic.SystemContent, messages []*
 	}
 
 	// System prompt counts as the first message (matches converter prepend logic).
-	hashOne(anthropicSystemText(system))
+	// Use the full text for system blocks (no 100-byte truncation).
+	for _, sysTxt := range anthropicSystemText(system) {
+		hashOne(sysTxt)
+	}
 
 	for i := 0; i < len(messages) && len(hashes) < 5; i++ {
 		msg := messages[i]
@@ -121,7 +131,10 @@ func (e *PromptTextLenExtractor) Features(req *octollm.Request) (any, error) {
 		}
 		return allMsgTextLen, nil
 	case *anthropic.ClaudeMessagesRequest:
-		allMsgTextLen := len([]rune(anthropicSystemText(v.System)))
+		allMsgTextLen := 0
+		for _, sysTxt := range anthropicSystemText(v.System) {
+			allMsgTextLen += len([]rune(sysTxt))
+		}
 		for _, msg := range v.Messages {
 			allMsgTextLen += len([]rune(combinedTextForAnthropicMessage(msg)))
 		}

--- a/pkg/engines/rule-engine/simple_features_test.go
+++ b/pkg/engines/rule-engine/simple_features_test.go
@@ -392,6 +392,30 @@ func TestMessage5Hash_Features_Anthropic(t *testing.T) {
 			},
 			expected: "8dca59b1-a89afb9a-5bf09c53-54fb23c2-ad98232b",
 		},
+		{
+			name: "ignore_anthropic_header",
+			req: anthropic.ClaudeMessagesRequest{
+				Model: "gpt-3.5-turbo",
+				System: anthropic.SystemBlocks{
+					{
+						Type: "text",
+						Text: "x-anthropic-billing-header: cc_version=2.1.117.e85; cc_entrypoint=cli; cch=00000;",
+					},
+					{
+						Type: "text",
+						Text: "You are Claude Code, Anthropic's official CLI for Claude.",
+					},
+					{
+						Type: "text",
+						Text: "Generate a concise, sentence-case title (3-7 words) that captures the main topic or goal of this coding session. The title should be clear enough that the user recognizes the session in a list. Use sentence case: capitalize only the first word and proper nouns.\n\nReturn JSON with a single \"title\" field.\n\nGood examples:\n{\"title\": \"Fix login button on mobile\"}\n{\"title\": \"Add OAuth authentication\"}\n{\"title\": \"Debug failing CI tests\"}\n{\"title\": \"Refactor API client error handling\"}\n\nBad (too vague): {\"title\": \"Code changes\"}\nBad (too long): {\"title\": \"Investigate and fix the issue where the login button does not respond on mobile devices\"}\nBad (wrong case): {\"title\": \"Fix Login Button On Mobile\"}",
+					},
+				},
+				Messages: []*anthropic.MessageParam{
+					{Role: "user", Content: []anthropic.MessageContent{anthropic.MessageContentString("hello")}},
+				},
+			},
+			expected: "d6a59d1f-5f5cd586-29790936",
+		},
 	}
 
 	t.Run("string", func(t *testing.T) {


### PR DESCRIPTION
anthropicSystemText now returns []string (one entry per block) and skips the first block when it carries a billing-head marker. All callers — PromptTextLenExtractor, computeAnthropicMessage5Hashes (which also gains full-text hashing for system blocks), anthropicFirstMessageText — are updated accordingly. The Claude→OpenAI converter applies the same skip when converting SystemBlocks to system messages.