### PR TITLE
fix: prevent goroutine panics from crashing the process

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,3 +88,4 @@ Example configs in `/examples/` demonstrate minimal setup, rules, protocol conve
 - Thread-safe caching with RWMutex in ModelRepo and RuleComposer
 - Builder pattern for HTTPEndpoint configuration
 - Custom error types: `UpstreamHTTPError` vs handler errors
+- Use `octollm.SafeGo(req, fn)` instead of bare `go` for any goroutine spawned inside request or stream processing (e.g. fire-and-forget replication, async stream draining). gin.Recovery and similar middleware only recover panics on the handler goroutine; a panic on a separately spawned goroutine will crash the process.

--- a/pkg/engines/client/http.go
+++ b/pkg/engines/client/http.go
@@ -225,9 +225,9 @@ func (e *HTTPEndpoint) Process(req *octollm.Request) (*octollm.Response, error) 
 	streamParser, streamingType := e.streamParser(req)
 	switch streamingType {
 	case StreamingTypeSSE:
-		go e.processSSEStream(ctx, req, resp, ch, streamParser)
+		octollm.SafeGo(req, func() { e.processSSEStream(ctx, req, resp, ch, streamParser) })
 	case StreamingTypeJSON:
-		go e.processJSONStream(ctx, req, resp, ch, streamParser)
+		octollm.SafeGo(req, func() { e.processJSONStream(ctx, req, resp, ch, streamParser) })
 	default:
 		cancel() // just for the linter
 		return nil, fmt.Errorf("unsupported streaming type %s", streamingType)

--- a/pkg/engines/converter/claude.go
+++ b/pkg/engines/converter/claude.go
@@ -40,7 +40,7 @@ func (e *ChatCompletionToClaudeMessages) Process(req *octollm.Request) (*octollm
 
 	// Convert Response
 	if resp.Stream != nil {
-		newStream, err := e.convertStreamResponse(req.Context(), resp.Stream)
+		newStream, err := e.convertStreamResponse(req, resp.Stream)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert stream response body: %w", err)
 		}
@@ -406,13 +406,14 @@ func (e *ChatCompletionToClaudeMessages) convertNonStreamResponseBody(ctx contex
 	return newBody, nil
 }
 
-func (e *ChatCompletionToClaudeMessages) convertStreamResponse(ctx context.Context, src *octollm.StreamChan) (*octollm.StreamChan, error) {
+func (e *ChatCompletionToClaudeMessages) convertStreamResponse(req *octollm.Request, src *octollm.StreamChan) (*octollm.StreamChan, error) {
 	inCh := src.Chan()
 	outCh := make(chan *octollm.StreamChunk)
 
 	intPtr := func(i int) *int { return &i }
 
-	go func() {
+	octollm.SafeGo(req, func() {
+		ctx := req.Context()
 		defer close(outCh)
 		defer src.Close()
 
@@ -763,7 +764,7 @@ func (e *ChatCompletionToClaudeMessages) convertStreamResponse(ctx context.Conte
 				}
 			}
 		}
-	}()
+	})
 
 	newStream := octollm.NewStreamChan(outCh, nil)
 	return newStream, nil

--- a/pkg/engines/converter/claude_test.go
+++ b/pkg/engines/converter/claude_test.go
@@ -1081,7 +1081,8 @@ func TestChatCompletionsToClaudeMessages_convertNonStreamResponseBody_MultipleTo
 }
 
 func testChatCompletionsToClaudeMessages_convertStreamResponse(t *testing.T, openaiRespJSON, expectedClaudeRespJSON []string) {
-	ctx := context.Background()
+	httpReq, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, "/", nil)
+	req := octollm.NewRequest(httpReq, octollm.APIFormatChatCompletions)
 	converter := NewChatCompletionToClaudeMessages(nil)
 
 	inCh := make(chan *octollm.StreamChunk)
@@ -1097,7 +1098,7 @@ func testChatCompletionsToClaudeMessages_convertStreamResponse(t *testing.T, ope
 	}()
 	inStream := octollm.NewStreamChan(inCh, closeFunc)
 
-	dstStream, err := converter.convertStreamResponse(ctx, inStream)
+	dstStream, err := converter.convertStreamResponse(req, inStream)
 	require.NoError(t, err)
 
 	i := 0

--- a/pkg/engines/limiter/concurrency_color_limiter.go
+++ b/pkg/engines/limiter/concurrency_color_limiter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"runtime/debug"
 	"time"
 
 	"github.com/google/uuid"
@@ -418,6 +419,11 @@ end
 // renewMemberSingle periodically renews the member's score for single key
 func (e *ConcurrencyColorLimiterEngine) renewMemberSingle(ctx context.Context, key, memberID string, done chan struct{}) {
 	defer close(done)
+	defer func() {
+		if p := recover(); p != nil {
+			slog.ErrorContext(ctx, "panic in renewal goroutine", "err", p, "stack", string(debug.Stack()))
+		}
+	}()
 	ticker := time.NewTicker(1 * time.Minute)
 	defer ticker.Stop()
 
@@ -450,6 +456,11 @@ func (e *ConcurrencyColorLimiterEngine) renewMemberSingle(ctx context.Context, k
 // renewMemberDual periodically renews the member's score for dual keys
 func (e *ConcurrencyColorLimiterEngine) renewMemberDual(ctx context.Context, ownKey, tier0Key, memberID string, done chan struct{}) {
 	defer close(done)
+	defer func() {
+		if err := recover(); err != nil {
+			slog.ErrorContext(ctx, "panic in renewal goroutine", "err", err, "stack", string(debug.Stack()))
+		}
+	}()
 	ticker := time.NewTicker(1 * time.Minute)
 	defer ticker.Stop()
 

--- a/pkg/engines/limiter/concurrency_color_marker.go
+++ b/pkg/engines/limiter/concurrency_color_marker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"runtime/debug"
 	"time"
 
 	"github.com/google/uuid"
@@ -357,6 +358,11 @@ return {1}
 // renewMember periodically renews the member's score for N keys
 func (e *ConcurrencyColorMarkerEngine) renewMember(ctx context.Context, keys []string, memberID string, done chan struct{}) {
 	defer close(done)
+	defer func() {
+		if err := recover(); err != nil {
+			slog.ErrorContext(ctx, "panic in renewal goroutine", "err", err, "stack", string(debug.Stack()))
+		}
+	}()
 	ticker := time.NewTicker(1 * time.Minute)
 	defer ticker.Stop()
 

--- a/pkg/engines/limiter/concurrency_limiter.go
+++ b/pkg/engines/limiter/concurrency_limiter.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"runtime/debug"
 	"time"
 
 	"github.com/google/uuid"
@@ -161,6 +162,11 @@ func (e *ConcurrencyLimiterEngine) Process(req *octollm.Request) (*octollm.Respo
 // renewMember periodically renews the member's score
 func (e *ConcurrencyLimiterEngine) renewMember(ctx context.Context, memberID string, done chan struct{}) {
 	defer close(done)
+	defer func() {
+		if err := recover(); err != nil {
+			slog.ErrorContext(ctx, "panic in renewal goroutine", "err", err, "stack", string(debug.Stack()))
+		}
+	}()
 	ticker := time.NewTicker(1 * time.Minute)
 	defer ticker.Stop()
 

--- a/pkg/engines/mock/openai.go
+++ b/pkg/engines/mock/openai.go
@@ -89,7 +89,7 @@ func (e *MockEndpoint) openAIStreamResponse(req *octollm.Request, v *openai.Chat
 	ch := make(chan *octollm.StreamChunk)
 	ctx, cancel := context.WithCancel(req.Context())
 
-	go func() {
+	octollm.SafeGo(req, func() {
 		defer close(ch)
 		time.Sleep(e.TTFT)
 		for _, c := range rOutput {
@@ -152,7 +152,7 @@ func (e *MockEndpoint) openAIStreamResponse(req *octollm.Request, v *openai.Chat
 			slog.InfoContext(ctx, fmt.Sprintf("[http-endpoint] context canceled during stream response: %v", ctx.Err()))
 			return
 		}
-	}()
+	})
 
 	streamChan := octollm.NewStreamChan(ch, cancel)
 	resp := octollm.NewStreamResponse(200, http.Header{"Content-Type": {"text/event-stream"}}, streamChan)

--- a/pkg/engines/moderator/moderator.go
+++ b/pkg/engines/moderator/moderator.go
@@ -165,7 +165,7 @@ func (e *TextModeratorEngine) Process(req *octollm.Request) (*octollm.Response, 
 	newChunks := make(chan *octollm.StreamChunk)
 	originalChunks := resp.Stream
 	ctx, cancel := context.WithCancel(req.Context())
-	go func() {
+	octollm.SafeGo(req, func() {
 		defer close(newChunks)
 
 		moderateEvery := e.ModerateStreamEvery
@@ -259,7 +259,7 @@ func (e *TextModeratorEngine) Process(req *octollm.Request) (*octollm.Response, 
 				}
 			}
 		}
-	}()
+	})
 	resp.Stream = octollm.NewStreamChan(newChunks, func() {
 		originalChunks.Close()
 		cancel()

--- a/pkg/engines/rewrite.go
+++ b/pkg/engines/rewrite.go
@@ -6,9 +6,10 @@ import (
 	"log/slog"
 
 	"github.com/expr-lang/expr"
+	"github.com/tidwall/sjson"
+
 	"github.com/infinigence/octollm/pkg/exprenv"
 	"github.com/infinigence/octollm/pkg/octollm"
-	"github.com/tidwall/sjson"
 )
 
 type RewritePolicy struct {
@@ -169,7 +170,7 @@ func (e *RewriteEngine) Process(req *octollm.Request) (*octollm.Response, error)
 		rewritenChunk := make(chan *octollm.StreamChunk)
 		originalStream := resp.Stream
 		ctx, cancel := context.WithCancel(req.Context())
-		go func() {
+		octollm.SafeGo(req, func() {
 			defer close(rewritenChunk)
 			for chunk := range originalStream.Chan() {
 				b, err := chunk.Body.Bytes()
@@ -185,7 +186,7 @@ func (e *RewriteEngine) Process(req *octollm.Request) (*octollm.Response, error)
 					return
 				}
 			}
-		}()
+		})
 		slog.DebugContext(req.Context(), "[RewriteEngine.Run] stream chunk rewritten")
 		resp.Stream = octollm.NewStreamChan(rewritenChunk, func() {
 			originalStream.Close()

--- a/pkg/engines/traffic-replication/traffic_replication.go
+++ b/pkg/engines/traffic-replication/traffic_replication.go
@@ -127,11 +127,11 @@ func (e *TrafficReplicationEngine) Process(req *octollm.Request) (*octollm.Respo
 				continue
 			}
 
-			go func(engine octollm.Engine, r *octollm.Request, cancel context.CancelFunc) {
+			octollm.SafeGo(reqC, func() {
 				defer cancel()
-				resp, err := engine.Process(r)
+				resp, err := item.TrafficReplicationEngine.Process(reqC)
 				if err != nil {
-					slog.ErrorContext(r.Context(), fmt.Sprintf("[TrafficReplication] replication error: %v", err))
+					slog.ErrorContext(reqC.Context(), fmt.Sprintf("[TrafficReplication] replication error: %v", err))
 					return
 				}
 				// Close response resources to avoid leaks. For streaming, drain until
@@ -148,7 +148,7 @@ func (e *TrafficReplicationEngine) Process(req *octollm.Request) (*octollm.Respo
 						_ = resp.Body.Close()
 					}
 				}
-			}(item.TrafficReplicationEngine, reqC, cancel)
+			})
 		}
 	}
 

--- a/pkg/octollm/goroutine.go
+++ b/pkg/octollm/goroutine.go
@@ -1,0 +1,26 @@
+package octollm
+
+import (
+	"log/slog"
+	"runtime/debug"
+)
+
+// SafeGo runs fn in a new goroutine with a deferred panic recovery.
+// Use SafeGo instead of a bare go statement for goroutines spawned inside request handlers:
+// middleware-level recovery (e.g. gin.Recovery) only catches panics on the handler goroutine
+// and cannot recover panics that occur on separately spawned goroutines.
+// Any panic is logged as an error with its stack trace using the request's context and does
+// not propagate — callers that need to know about failures should use an explicit error channel.
+func SafeGo(req *Request, fn func()) {
+	go func() {
+		defer func() {
+			if err := recover(); err != nil {
+				slog.ErrorContext(req.Context(), "panic in goroutine",
+					"err", err,
+					"stack", string(debug.Stack()),
+				)
+			}
+		}()
+		fn()
+	}()
+}

--- a/pkg/octollm/handler.go
+++ b/pkg/octollm/handler.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
@@ -82,6 +83,11 @@ func httpSSEHandler(engine Engine, format APIFormat, parser Parser) http.Handler
 
 		if flusher, ok := w.(http.Flusher); ok && heartbeatIntervalSecs > 0 {
 			wg.Go(func() {
+				defer func() {
+					if err := recover(); err != nil {
+						slog.ErrorContext(r.Context(), "panic in keep-alive goroutine", "err", err, "stack", string(debug.Stack()))
+					}
+				}()
 				select {
 				case <-keepAliveCtx.Done():
 					return


### PR DESCRIPTION
Add octollm.SafeGo to wrap goroutines spawned inside request and stream processing with panic recovery and structured logging. gin.Recovery only covers the handler goroutine; unrecovered panics on separately spawned goroutines crash the process. Renewal goroutines in limiters get inline recover blocks since they operate without a *Request.