### PR TITLE
limiter: global + per-priority color limits; independent marker tiers

### DIFF
--- a/pkg/engines/limiter/concurrency_color_limiter.go
+++ b/pkg/engines/limiter/concurrency_color_limiter.go
@@ -30,33 +30,27 @@ type ConcurrencyColorLimiterEngine struct {
 
 var _ octollm.Engine = (*ConcurrencyColorLimiterEngine)(nil)
 
-// NewConcurrencyColorLimiterEngine creates a concurrency color limiter engine with priority-based limits
-// redisClient: Redis client
-// key: Redis key prefix for storing concurrency counts (each tier uses key:tier_N)
-// rates: Concurrency limit array for each priority tier (must be non-increasing), e.g., [200, 100, 50]
+// NewConcurrencyColorLimiterEngine creates a concurrency color limiter engine with priority-based limits.
 //
-//	means tier 0 (priority 2): 200 concurrent, tier 1 (priority 1): 100 concurrent, tier 2 (priority 0): 50 concurrent
+// totalConcurrency is the global concurrent cap (YAML `concurrency`): tier 0, highest-priority band only.
+// perPriorityRates are per-priority caps (YAML `concurrency_rates`) in order from the next band down; values greater
+// than or equal to totalConcurrency are effectively capped by the global tier. Negative entries are treated as 0 (empty band).
 //
-// timeout: Timeout duration for member expiration, must be greater than 0
-// nameSpace: Namespace for isolating priority across different namespaces, marker and limiter within the same nameSpace can communicate
-// next: Next engine
+// Configuration rules:
+//   - Only totalConcurrency (>0) and empty perPriorityRates → single tier [total] (legacy flat limit).
+//   - Only perPriorityRates (non-empty) and totalConcurrency <= 0 → tier 0 is the sum of perPriorityRates (after clamping negatives to 0); remaining tiers use perPriorityRates.
+//   - Both set → internal rates are append([totalConcurrency], perPriorityRates...).
+//   - totalConcurrency <= 0 and empty perPriorityRates → disabled (pass-through).
 //
-// Working principle:
-//   - Priority mapping: priority = len(rates) - 1 - tierIdx (same as marker)
-//   - Max priority requests (tier 0): only check tier 0 concurrency
-//   - Lower priority requests: atomically check own tier and tier 0 with reservation
-//   - Reservation mechanism: reserve N slots in tier 0 where N = priority difference (tierIdx)
-//     This ensures higher priority requests always have slots available
+// timeout: Timeout duration for member expiration, must be greater than 0 when the limiter is enabled.
+// nameSpace: Namespace for isolating priority across marker/limiter.
 //
-// Example: rates=[200, 100, 50] (supports priority 2, 1, 0)
-// - Tier 0: 200 concurrent → Priority 2 (highest)
-// - Tier 1: 100 concurrent → Priority 1 (medium)
-// - Tier 2: 50 concurrent → Priority 0 (lowest)
-// - Priority 2: only check tier 0 < 200
-// - Priority 1: check tier 1 < 100 AND tier 0 < (200-1)=199
-// - Priority 0: check tier 2 < 50 AND tier 0 < (200-2)=198
-func NewConcurrencyColorLimiterEngine(redisClient *redis.Client, key string, rates []int, timeout time.Duration, nameSpace string, next octollm.Engine) (*ConcurrencyColorLimiterEngine, error) {
-	// If rates is empty, return an engine that directly passes through
+// Working principle (unchanged Lua): priority = len(rates)-1-tierIdx; lower priorities reserve slots in tier 0.
+func NewConcurrencyColorLimiterEngine(redisClient *redis.Client, key string, totalConcurrency int, perPriorityRates []int, timeout time.Duration, nameSpace string, next octollm.Engine) (*ConcurrencyColorLimiterEngine, error) {
+	rates, err := buildTotalPlusPerPriorityLimits(totalConcurrency, perPriorityRates)
+	if err != nil {
+		return nil, err
+	}
 	if len(rates) == 0 {
 		return &ConcurrencyColorLimiterEngine{
 			redisClient:         redisClient,
@@ -77,15 +71,11 @@ func NewConcurrencyColorLimiterEngine(redisClient *redis.Client, key string, rat
 	if timeout <= 0 {
 		return nil, fmt.Errorf("timeout must be positive")
 	}
-	filteredRates, filtered := filterDecreasingRates(rates)
-	if filtered {
-		slog.Warn(fmt.Sprintf("concurrency_rates must be non-increasing, filtered from %v to %v (removed %d invalid suffix values)", rates, filteredRates, len(rates)-len(filteredRates)))
-	}
 
 	return &ConcurrencyColorLimiterEngine{
 		redisClient:         redisClient,
 		key:                 key,
-		concurrencyRates:    filteredRates,
+		concurrencyRates:    rates,
 		timeout:             timeout,
 		nameSpace:           nameSpace,
 		acquireSingleScript: redis.NewScript(acquireSingleLuaScript),
@@ -272,6 +262,39 @@ func (e *ConcurrencyColorLimiterEngine) getPriorityFromContext(ctx context.Conte
 	}
 
 	return priority, true
+}
+
+// buildTotalPlusPerPriorityLimits builds tier limits for color limiters: [total] or [total, ...per] or [sum(per), ...per].
+// When only per-priority rates are set, tier 0 is the sum of those caps so total in-flight work has a finite headroom.
+// Shared by concurrency and request color limiters.
+func buildTotalPlusPerPriorityLimits(totalConcurrency int, perPriorityRates []int) ([]int, error) {
+	clamped := make([]int, len(perPriorityRates))
+	for i, v := range perPriorityRates {
+		if v < 0 {
+			v = 0
+		}
+		clamped[i] = v
+	}
+	if len(clamped) == 0 {
+		if totalConcurrency <= 0 {
+			return nil, nil
+		}
+		return []int{totalConcurrency}, nil
+	}
+	if totalConcurrency > 0 {
+		out := make([]int, 0, 1+len(clamped))
+		out = append(out, totalConcurrency)
+		out = append(out, clamped...)
+		return out, nil
+	}
+	sum := 0
+	for _, v := range clamped {
+		sum += v
+	}
+	out := make([]int, 0, 1+len(clamped))
+	out = append(out, sum)
+	out = append(out, clamped...)
+	return out, nil
 }
 
 func filterDecreasingRates(rates []int) ([]int, bool) {

--- a/pkg/engines/limiter/concurrency_color_limiter_test.go
+++ b/pkg/engines/limiter/concurrency_color_limiter_test.go
@@ -16,10 +16,10 @@ import (
 
 func TestFilterDecreasingRates(t *testing.T) {
 	tests := []struct {
-		name          string
-		in            []int
-		wantOut       []int
-		wantFiltered  bool
+		name         string
+		in           []int
+		wantOut      []int
+		wantFiltered bool
 	}{
 		{
 			name:         "empty",
@@ -86,29 +86,64 @@ func newConcurrencyColorLimiterTestRequest(t *testing.T, ns string, priority *in
 	return r.WithContext(ctx)
 }
 
+func TestBuildTotalPlusPerPriorityLimits(t *testing.T) {
+	got, err := buildTotalPlusPerPriorityLimits(80, []int{70, 50, 30})
+	assert.NoError(t, err)
+	assert.Equal(t, []int{80, 70, 50, 30}, got)
+
+	got, err = buildTotalPlusPerPriorityLimits(80, []int{0, 50, 30})
+	assert.NoError(t, err)
+	assert.Equal(t, []int{80, 0, 50, 30}, got)
+
+	got, err = buildTotalPlusPerPriorityLimits(0, []int{70, 50, 30})
+	assert.NoError(t, err)
+	assert.Equal(t, []int{150, 70, 50, 30}, got)
+
+	got, err = buildTotalPlusPerPriorityLimits(0, []int{-1, 50})
+	assert.NoError(t, err)
+	assert.Equal(t, []int{50, 0, 50}, got)
+
+	got, err = buildTotalPlusPerPriorityLimits(80, []int{80, 50})
+	assert.NoError(t, err)
+	assert.Equal(t, []int{80, 80, 50}, got)
+
+	got, err = buildTotalPlusPerPriorityLimits(10, []int{5, 6, 1})
+	assert.NoError(t, err)
+	assert.Equal(t, []int{10, 5, 6, 1}, got)
+
+	got, err = buildTotalPlusPerPriorityLimits(5, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, []int{5}, got)
+
+	got, err = buildTotalPlusPerPriorityLimits(0, nil)
+	assert.NoError(t, err)
+	assert.Nil(t, got)
+}
+
 func TestNewConcurrencyColorLimiterEngine_ValidationAndFiltering(t *testing.T) {
 	next := &nextStubEngine{}
 
-	// empty rates -> disabled (pass-through)
-	e, err := NewConcurrencyColorLimiterEngine(nil, "k", nil, time.Second, "ns", next)
+	e, err := NewConcurrencyColorLimiterEngine(nil, "k", 0, nil, time.Second, "ns", next)
 	assert.NoError(t, err)
 	assert.Nil(t, e.concurrencyRates)
 	assert.Nil(t, e.acquireSingleScript)
 	assert.Nil(t, e.acquireDualScript)
 
-	// timeout must be positive when enabled
-	_, err = NewConcurrencyColorLimiterEngine(nil, "k", []int{2, 1}, 0, "ns", next)
+	_, err = NewConcurrencyColorLimiterEngine(nil, "k", 2, []int{1}, 0, "ns", next)
 	assert.Error(t, err)
 
-	// rates that break non-increasing order get filtered (stop at first increase)
-	e, err = NewConcurrencyColorLimiterEngine(nil, "k", []int{10, 5, 6, 1}, time.Second, "ns", next)
+	e, err = NewConcurrencyColorLimiterEngine(nil, "k", 10, []int{10}, time.Second, "ns", next)
 	assert.NoError(t, err)
-	assert.Equal(t, []int{10, 5}, e.concurrencyRates)
+	assert.Equal(t, []int{10, 10}, e.concurrencyRates)
+
+	e, err = NewConcurrencyColorLimiterEngine(nil, "k", 10, []int{5, 6, 1}, time.Second, "ns", next)
+	assert.NoError(t, err)
+	assert.Equal(t, []int{10, 5, 6, 1}, e.concurrencyRates)
 }
 
 func TestConcurrencyColorLimiter_PassThroughWhenDisabled(t *testing.T) {
 	next := &nextStubEngine{resp: &octollm.Response{StatusCode: 200}}
-	e, err := NewConcurrencyColorLimiterEngine(nil, "k", nil, time.Second, "ns", next)
+	e, err := NewConcurrencyColorLimiterEngine(nil, "k", 0, nil, time.Second, "ns", next)
 	assert.NoError(t, err)
 
 	req := newConcurrencyColorLimiterTestRequest(t, "ns", nil)
@@ -128,7 +163,7 @@ func TestConcurrencyColorLimiter_PriorityMappingAndReservation(t *testing.T) {
 	next := &nextStubEngine{resp: &octollm.Response{StatusCode: 200, Body: octollm.NewBodyFromBytes([]byte("ok"), nil)}}
 
 	// rates=[2,1] supports priority 1 (tier0, limit2) and priority 0 (tier1, limit1 with reservedSlots=1)
-	e, err := NewConcurrencyColorLimiterEngine(client, "limiter-key", []int{2, 1}, 10*time.Second, ns, next)
+	e, err := NewConcurrencyColorLimiterEngine(client, "limiter-key", 2, []int{1}, 10*time.Second, ns, next)
 	assert.NoError(t, err)
 
 	// Hold one max-priority slot (tier0Count becomes 1)
@@ -151,7 +186,7 @@ func TestConcurrencyColorLimiter_PriorityMappingAndReservation(t *testing.T) {
 	assert.NoError(t, resp2.Body.Close())
 }
 
-// [3,3,3]: same numeric limits per tier; asserts p2 allows 3, p1 allows 2, p0 allows 1 (tier0 reservation still differs by priority).
+// [4,3,3,3]: global cap 4 on tier 0; lower tiers 3 each — reservation still caps p2/p1/p0 differently.
 func TestConcurrencyColorLimiter_EqualTierLimits_ReservationCaps(t *testing.T) {
 	t.Parallel()
 	mr := miniredis.RunT(t)
@@ -160,11 +195,26 @@ func TestConcurrencyColorLimiter_EqualTierLimits_ReservationCaps(t *testing.T) {
 	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
 	ns := "limiter-ns-eq333"
 	next := &nextNewBodyPerCallEngine{}
-	e, err := NewConcurrencyColorLimiterEngine(client, "limiter-key-eq333", []int{3, 3, 3}, 10*time.Second, ns, next)
+	e, err := NewConcurrencyColorLimiterEngine(client, "limiter-key-eq333", 4, []int{3, 3, 3}, 10*time.Second, ns, next)
 	assert.NoError(t, err)
 
-	p2 := 2
+	p3 := 3
 	var held []*octollm.Response
+	for i := 0; i < 4; i++ {
+		resp, err := e.Process(newConcurrencyColorLimiterTestRequest(t, ns, &p3))
+		assert.NoError(t, err, "p3 request %d", i+1)
+		assert.NotNil(t, resp)
+		held = append(held, resp)
+	}
+	_, err = e.Process(newConcurrencyColorLimiterTestRequest(t, ns, &p3))
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrRateLimitReached)
+	for _, r := range held {
+		assert.NoError(t, r.Body.Close())
+	}
+	held = held[:0]
+
+	p2 := 2
 	for i := 0; i < 3; i++ {
 		resp, err := e.Process(newConcurrencyColorLimiterTestRequest(t, ns, &p2))
 		assert.NoError(t, err, "p2 request %d", i+1)
@@ -214,7 +264,7 @@ func TestConcurrencyColorLimiter_NoPriorityDefaultsToLowest(t *testing.T) {
 	next := &nextStubEngine{resp: &octollm.Response{StatusCode: 200, Body: octollm.NewBodyFromBytes([]byte("ok"), nil)}}
 
 	// rates=[10,1] => default priority 0 maps to tier1, limit 1
-	e, err := NewConcurrencyColorLimiterEngine(client, "noprio-key", []int{10, 1}, 10*time.Second, ns, next)
+	e, err := NewConcurrencyColorLimiterEngine(client, "noprio-key", 10, []int{1}, 10*time.Second, ns, next)
 	assert.NoError(t, err)
 
 	// first allowed
@@ -251,16 +301,12 @@ func TestConcurrencyColor_MarkerLimiterChain_MarkerBottleneck_Allows2ThenRejects
 	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
 	ns := "chain-ns"
 
-	// Marker: non-decreasing limits with a plateau ([1,1,2]) — three tiers, last tier cap 2.
-	// Expected: #1 -> highest priority (tiers 0+2), #2 -> middle tier + last (still within last cap),
-	// #3 -> rejected when all tiers / last tier are full.
-	markerRates := []int{1, 1, 2}
+	// Marker: independent caps [1,1,0] — two non-zero bands (p1 then p0); third has no slot.
+	markerRates := []int{1, 1, 0}
 
-	// Limiter: non-increasing with a plateau ([3,3,2]); generous enough not to bottleneck marker.
-	limiterRates := []int{3, 3, 2}
-
+	// Limiter: built as concurrency=4, rates=[3,2] -> [4,3,2]; matches three marker priorities.
 	next := &nextNewBodyPerCallEngine{}
-	limiter, err := NewConcurrencyColorLimiterEngine(client, "chain-limiter", limiterRates, 10*time.Second, ns, next)
+	limiter, err := NewConcurrencyColorLimiterEngine(client, "chain-limiter", 4, []int{3, 2}, 10*time.Second, ns, next)
 	assert.NoError(t, err)
 	marker, err := NewConcurrencyColorMarkerEngine(client, "chain-marker", markerRates, 10*time.Second, ns, limiter)
 	assert.NoError(t, err)
@@ -293,12 +339,10 @@ func TestConcurrencyColor_MarkerLimiterChain_LimiterBottleneck_Allows1ThenReject
 	// Same marker shape as previous test but with equal low tiers ([1,1,2]).
 	markerRates := []int{1, 1, 2}
 
-	// Limiter: plateau on high tiers ([2,2,1]); for the 2nd request (priority 1) reservedSlots=1
-	// requires tier0Count < tier0Limit-1, which fails once tier0 already holds the first request.
-	limiterRates := []int{2, 2, 1}
-
+	// Limiter: concurrency=2, rates=[1,1] -> [2,1,1]; priority 1 needs tier0Count < tier0Limit-reservedSlots = 1,
+	// so the second in-flight (tier0 already 1) is rejected at the limiter, not the marker.
 	next := &nextNewBodyPerCallEngine{}
-	limiter, err := NewConcurrencyColorLimiterEngine(client, "chain-limiter-2", limiterRates, 10*time.Second, ns, next)
+	limiter, err := NewConcurrencyColorLimiterEngine(client, "chain-limiter-2", 2, []int{1, 1}, 10*time.Second, ns, next)
 	assert.NoError(t, err)
 	marker, err := NewConcurrencyColorMarkerEngine(client, "chain-marker-2", markerRates, 10*time.Second, ns, limiter)
 	assert.NoError(t, err)
@@ -323,4 +367,3 @@ func TestConcurrencyColor_MarkerLimiterChain_LimiterBottleneck_Allows1ThenReject
 
 	assert.NoError(t, resp3.Body.Close())
 }
-

--- a/pkg/engines/limiter/concurrency_color_marker.go
+++ b/pkg/engines/limiter/concurrency_color_marker.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"runtime/debug"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -27,29 +28,31 @@ type ConcurrencyColorMarkerEngine struct {
 
 var _ octollm.Engine = (*ConcurrencyColorMarkerEngine)(nil)
 
-// NewConcurrencyColorMarkerEngine creates a multi-tier concurrency-based marker with priority assignment
-// redisClient: Redis client
-// key: Redis key prefix for storing concurrency counts (each tier uses key:tier_N)
-// rates: Per-priority concurrency slots, highest priority first. Each element is its own cap; the sum is total concurrency.
-// Negative values are treated as 0. Leading zeros are trimmed (no effect before the first positive slot).
-// Zeros after the first positive slot mean that priority band has no slots (skipped).
+// NewConcurrencyColorMarkerEngine creates a multi-tier concurrency-based marker with priority assignment.
 //
-//	Priority is: len(rates) - 1 - tierIdx (tier 0 = highest priority).
-//
-// timeout: Timeout duration for member expiration, must be greater than 0
-// nameSpace: Namespace for isolating priority across different namespaces, marker and limiter within the same nameSpace can communicate
-// next: Next engine
+// Parameters:
+//   - redisClient: Redis client.
+//   - key: Redis key prefix for storing concurrency counts (each tier uses key:tier_N).
+//   - rates: Per-tier concurrency caps, highest priority first. Each element caps that tier independently;
+//     total concurrency is the sum. Negative values are clamped to 0. Leading zeros are trimmed (which
+//     shrinks the priority range, since priority numbers are derived from the post-trim length). Zeros
+//     after the first positive entry keep the tier in place but with no slots (always skipped).
+//     Priority assigned to a request: len(rates) - 1 - tierIdx, so tier 0 is the highest priority.
+//   - timeout: Member expiration duration; must be positive.
+//   - nameSpace: Namespace for isolating priority between marker/limiter pairs. Marker and limiter sharing
+//     a namespace can communicate via context.
+//   - next: Next engine in the chain.
 //
 // Working principle:
-// - Priority number: larger = higher priority (priority 2 > priority 1 > priority 0)
-// - A request tries tier 0, then tier 1, …; the first tier with limit>0 and available capacity wins
-// - Acquisition occupies only that tier’s key (one slot in that band)
+//   - Larger priority number = higher priority (priority 2 > priority 1 > priority 0).
+//   - A request scans tier 0, tier 1, ...; the first tier with limit>0 and available capacity wins.
+//   - Acquisition occupies exactly one slot in the winning tier; lower tiers are not consulted further.
 //
 // Example: rates=[3, 2, 1]
-// - Slots 1–3 → priority 2; 4–5 → priority 1; 6th → priority 0; 7th rejected
+//   - Slots 1-3 -> priority 2; 4-5 -> priority 1; 6th -> priority 0; 7th rejected.
 //
 // Example: rates=[3, 0, 0]
-// - Three slots, all priority 2; lower bands are empty (limit 0)
+//   - Three slots, all priority 2; lower bands are empty (limit 0).
 func NewConcurrencyColorMarkerEngine(redisClient *redis.Client, key string, rates []int, timeout time.Duration, nameSpace string, next octollm.Engine) (*ConcurrencyColorMarkerEngine, error) {
 	// If rates is empty, return an engine that directly passes through
 	if len(rates) == 0 {
@@ -120,7 +123,7 @@ func (e *ConcurrencyColorMarkerEngine) allow(ctx context.Context) (newCtx contex
 	}
 
 	// Build ARGV: numTiers, limit1, limit2, ..., nowUnix, expireBefore, memberID
-	args := make([]interface{}, 0, 1+numTiers+3)
+	args := make([]any, 0, 1+numTiers+3)
 	args = append(args, numTiers)
 	for _, limit := range e.rates {
 		args = append(args, limit)
@@ -134,34 +137,30 @@ func (e *ConcurrencyColorMarkerEngine) allow(ctx context.Context) (newCtx contex
 		return ctx, func() {}, fmt.Errorf("acquire script error: %w", err)
 	}
 
-	results, ok := result.([]interface{})
+	results, ok := result.([]any)
 	if !ok || len(results) < 2 {
 		slog.ErrorContext(ctx, fmt.Sprintf("unexpected script result format, key: %s", e.key))
 		return ctx, func() {}, fmt.Errorf("unexpected script result format")
 	}
 
 	acquired, _ := results[0].(int64)
+	countsRaw, _ := results[1].([]any)
+	counts := make([]int64, len(countsRaw))
+	for i, v := range countsRaw {
+		c, _ := v.(int64)
+		counts[i] = c
+	}
+
 	if acquired == 0 {
 		// All tiers exhausted
-		slog.WarnContext(ctx, fmt.Sprintf("all tiers exhausted, key: %s", e.key))
+		slog.WarnContext(ctx, fmt.Sprintf("all tiers exhausted, key: %s, usage: %s", e.key, formatTierUsage(counts, e.rates)))
 		return ctx, func() {}, ErrRateLimitReached
 	}
 
 	// acquired > 0: priority (1-based in Lua, convert to 0-based)
 	priority := int(acquired) - 1
 	acquiredTierIdx := numTiers - 1 - priority
-
-	// Parse acquired keys indices from results[1]
-	acquiredKeysStr, _ := results[1].(string)
-	var acquiredKeys []string
-	if acquiredKeysStr != "" {
-		for _, idxStr := range []byte(acquiredKeysStr) {
-			idx := int(idxStr - '0')
-			if idx >= 0 && idx < numTiers {
-				acquiredKeys = append(acquiredKeys, keys[idx])
-			}
-		}
-	}
+	acquiredKeys := []string{keys[acquiredTierIdx]}
 
 	// Set priority to context
 	newCtx = e.setPriorityToContext(ctx, priority)
@@ -181,7 +180,7 @@ func (e *ConcurrencyColorMarkerEngine) allow(ctx context.Context) (newCtx contex
 		}
 	}
 
-	slog.InfoContext(ctx, fmt.Sprintf("acquired priority %d from tier %d, acquiredKeys: %v", priority, acquiredTierIdx, acquiredKeys))
+	slog.InfoContext(ctx, fmt.Sprintf("acquired priority %d from tier %d, acquiredKeys: %v, usage: %s", priority, acquiredTierIdx, acquiredKeys, formatTierUsage(counts, e.rates)))
 	return newCtx, done, nil
 }
 
@@ -221,6 +220,17 @@ func (e *ConcurrencyColorMarkerEngine) setPriorityToContext(ctx context.Context,
 	priorityStr := fmt.Sprintf("%s%d", ContextValuePrefixPriority, priority)
 	contextKey := contextKey(fmt.Sprintf("%s:%s", e.nameSpace, ContextKeyPriority))
 	return context.WithValue(ctx, contextKey, priorityStr)
+}
+
+// formatTierUsage formats per-tier "count/limit" usage as "(2/2 1/3 0/5)".
+// Assumes counts and limits have the same length; truncates to the shorter if not.
+func formatTierUsage(counts []int64, limits []int) string {
+	n := min(len(counts), len(limits))
+	parts := make([]string, n)
+	for i := range n {
+		parts[i] = fmt.Sprintf("%d/%d", counts[i], limits[i])
+	}
+	return "(" + strings.Join(parts, " ") + ")"
 }
 
 // normalizeConcurrencyMarkerRates clamps negatives to 0, trims leading zeros, and returns nil if no positive band remains.
@@ -278,9 +288,9 @@ func filterIncreasingRates(rates []int) ([]int, bool) {
 // ARGV[numTiers+3]: expireBefore
 // ARGV[numTiers+4]: memberID
 //
-// Returns: {priority, acquiredKeysIndices}
+// Returns: {priority, counts}
 // - priority: 0 means rejected, >0 means acquired with priority (1-based, convert to 0-based in Go)
-// - acquiredKeysIndices: string of key indices that were acquired (e.g., "02" means keys[0] and keys[2])
+// - counts: per-tier ZCARD after acquisition (length = numTiers)
 const concurrencyColorMarkerAquireLuaScript = `
 local numTiers = tonumber(ARGV[1])
 local limits = {}
@@ -291,35 +301,32 @@ local nowUnix = tonumber(ARGV[numTiers + 2])
 local expireBefore = tonumber(ARGV[numTiers + 3])
 local memberID = ARGV[numTiers + 4]
 
--- Clean up expired members from all tiers
+-- Clean up expired members and snapshot counts for all tiers in one pass
+local counts = {}
 for i = 1, numTiers do
     redis.call('ZREMRANGEBYSCORE', KEYS[i], '0', expireBefore)
+    counts[i] = redis.call('ZCARD', KEYS[i])
 end
 
--- Phase 1: First tier (highest priority) with limit>0 and free capacity wins; acquire only that tier
+-- Find first tier (highest priority) with limit>0 and free capacity
 local foundTierIdx = nil
 for tierIdx = 1, numTiers do
-    local lim = limits[tierIdx]
-    if lim > 0 then
-        local count = redis.call('ZCARD', KEYS[tierIdx])
-        if count < lim then
-            foundTierIdx = tierIdx
-            break
-        end
+    if limits[tierIdx] > 0 and counts[tierIdx] < limits[tierIdx] then
+        foundTierIdx = tierIdx
+        break
     end
 end
 
 if foundTierIdx == nil then
-    return {0, ""}
+    return {0, counts}
 end
-
-local priority = numTiers - foundTierIdx + 1
 
 redis.call('ZADD', KEYS[foundTierIdx], nowUnix, memberID)
 redis.call('EXPIRE', KEYS[foundTierIdx], 3600)
+counts[foundTierIdx] = counts[foundTierIdx] + 1
 
-local acquiredKeysStr = tostring(foundTierIdx - 1)
-return {priority, acquiredKeysStr}
+local priority = numTiers - foundTierIdx + 1
+return {priority, counts}
 `
 
 // Unified release script supporting N keys
@@ -381,7 +388,7 @@ func (e *ConcurrencyColorMarkerEngine) renewMember(ctx context.Context, keys []s
 				slog.ErrorContext(ctx, fmt.Sprintf("failed to renew member: %v, keys: %v, memberID: %s", err, keys, memberID))
 				continue
 			}
-			results, ok := result.([]interface{})
+			results, ok := result.([]any)
 			if !ok || len(results) != 1 {
 				slog.ErrorContext(ctx, fmt.Sprintf("unexpected renew script result format, keys: %v, memberID: %s", keys, memberID))
 				continue

--- a/pkg/engines/limiter/concurrency_color_marker.go
+++ b/pkg/engines/limiter/concurrency_color_marker.go
@@ -28,7 +28,12 @@ type ConcurrencyColorMarkerEngine struct {
 
 var _ octollm.Engine = (*ConcurrencyColorMarkerEngine)(nil)
 
-// NewConcurrencyColorMarkerEngine creates a multi-tier concurrency-based marker with priority assignment.
+// NewConcurrencyColorMarkerEngine creates a multi-tier concurrency-based marker with priority assignment
+// redisClient: Redis client
+// key: Redis key prefix for storing concurrency counts (each tier uses key:tier_N)
+// rates: Per-priority concurrency slots, highest priority first. Each element is its own cap; the sum is total concurrency.
+// Negative values are treated as 0. Only an empty rates slice disables the marker (pass-through).
+// A zero entry at any index means that priority band has no slots (skipped); e.g. rates=[0] rejects all traffic.
 //
 // Parameters:
 //   - redisClient: Redis client.
@@ -234,6 +239,7 @@ func formatTierUsage(counts []int64, limits []int) string {
 }
 
 // normalizeConcurrencyMarkerRates clamps negatives to 0, trims leading zeros, and returns nil if no positive band remains.
+// normalizeConcurrencyMarkerRates clamps negatives to 0 and returns a copy of the same length as rates.
 func normalizeConcurrencyMarkerRates(rates []int) ([]int, bool) {
 	if len(rates) == 0 {
 		return nil, false
@@ -247,17 +253,7 @@ func normalizeConcurrencyMarkerRates(rates []int) ([]int, bool) {
 		}
 		out[i] = v
 	}
-	start := 0
-	for start < len(out) && out[start] == 0 {
-		start++
-	}
-	if start > 0 {
-		altered = true
-	}
-	if start >= len(out) {
-		return nil, altered
-	}
-	return out[start:], altered
+	return out, altered
 }
 
 func filterIncreasingRates(rates []int) ([]int, bool) {

--- a/pkg/engines/limiter/concurrency_color_marker.go
+++ b/pkg/engines/limiter/concurrency_color_marker.go
@@ -30,35 +30,26 @@ var _ octollm.Engine = (*ConcurrencyColorMarkerEngine)(nil)
 // NewConcurrencyColorMarkerEngine creates a multi-tier concurrency-based marker with priority assignment
 // redisClient: Redis client
 // key: Redis key prefix for storing concurrency counts (each tier uses key:tier_N)
-// rates: Concurrency limit array for each priority tier (must be non-decreasing), e.g., [10, 50, 100]
+// rates: Per-priority concurrency slots, highest priority first. Each element is its own cap; the sum is total concurrency.
+// Negative values are treated as 0. Leading zeros are trimmed (no effect before the first positive slot).
+// Zeros after the first positive slot mean that priority band has no slots (skipped).
 //
-//	means tier 0 allows 10 concurrent, tier 1 allows 50 concurrent, tier 2 allows 100 concurrent
-//	Priority is calculated as: len(rates) - 1 - tierIdx
-//	So tier 0 → priority 2 (highest), tier 1 → priority 1, tier 2 → priority 0 (lowest)
+//	Priority is: len(rates) - 1 - tierIdx (tier 0 = highest priority).
 //
 // timeout: Timeout duration for member expiration, must be greater than 0
 // nameSpace: Namespace for isolating priority across different namespaces, marker and limiter within the same nameSpace can communicate
 // next: Next engine
 //
 // Working principle:
-// - Each tier has its own concurrency limit (non-decreasing)
 // - Priority number: larger = higher priority (priority 2 > priority 1 > priority 0)
-// - When a request comes in, it tries to acquire from tier 0 (smallest limit, highest priority) first
-// - Occupancy rule:
-//   - If acquired from tier 0 (highest priority): occupies tier 0 and last tier (lowest priority tier)
-//   - If acquired from tier 1: occupies tier 1 and last tier
-//   - If acquired from last tier (lowest priority): only occupies last tier
+// - A request tries tier 0, then tier 1, …; the first tier with limit>0 and available capacity wins
+// - Acquisition occupies only that tier’s key (one slot in that band)
 //
-// - If tier 0 fails, it tries tier 1, and so on
-// - If all tiers fail, the request is rejected
+// Example: rates=[3, 2, 1]
+// - Slots 1–3 → priority 2; 4–5 → priority 1; 6th → priority 0; 7th rejected
 //
-// Example: rates=[10, 50, 100]
-// - Tier 0: 10 concurrent → Priority 2 (highest)
-// - Tier 1: 50 concurrent → Priority 1 (medium)
-// - Tier 2: 100 concurrent → Priority 0 (lowest)
-// - Request tries tier 0 first: if available, occupies tier 0 and tier 2 → Priority 2
-// - If tier 0 full, tries tier 1: if available, occupies tier 1 and tier 2 → Priority 1
-// - If tier 1 full, tries tier 2: if available, occupies tier 2 only → Priority 0
+// Example: rates=[3, 0, 0]
+// - Three slots, all priority 2; lower bands are empty (limit 0)
 func NewConcurrencyColorMarkerEngine(redisClient *redis.Client, key string, rates []int, timeout time.Duration, nameSpace string, next octollm.Engine) (*ConcurrencyColorMarkerEngine, error) {
 	// If rates is empty, return an engine that directly passes through
 	if len(rates) == 0 {
@@ -79,15 +70,28 @@ func NewConcurrencyColorMarkerEngine(redisClient *redis.Client, key string, rate
 		return nil, fmt.Errorf("timeout must be positive")
 	}
 
-	filteredRates, filtered := filterIncreasingRates(rates)
-	if filtered {
-		slog.Warn(fmt.Sprintf("rates must be non-decreasing, filtered from %v to %v (removed %d invalid suffix values)", rates, filteredRates, len(rates)-len(filteredRates)))
+	normalizedRates, normalized := normalizeConcurrencyMarkerRates(rates)
+	if normalized {
+		slog.Warn(fmt.Sprintf("concurrency marker rates normalized from %v to %v", rates, normalizedRates))
+	}
+	if len(normalizedRates) == 0 {
+		return &ConcurrencyColorMarkerEngine{
+			redisClient:   redisClient,
+			key:           key,
+			rates:         nil,
+			timeout:       timeout,
+			nameSpace:     nameSpace,
+			acquireScript: nil,
+			releaseScript: nil,
+			renewScript:   nil,
+			next:          next,
+		}, nil
 	}
 
 	return &ConcurrencyColorMarkerEngine{
 		redisClient:   redisClient,
 		key:           key,
-		rates:         filteredRates,
+		rates:         normalizedRates,
 		timeout:       timeout,
 		nameSpace:     nameSpace,
 		acquireScript: redis.NewScript(concurrencyColorMarkerAquireLuaScript),
@@ -219,6 +223,33 @@ func (e *ConcurrencyColorMarkerEngine) setPriorityToContext(ctx context.Context,
 	return context.WithValue(ctx, contextKey, priorityStr)
 }
 
+// normalizeConcurrencyMarkerRates clamps negatives to 0, trims leading zeros, and returns nil if no positive band remains.
+func normalizeConcurrencyMarkerRates(rates []int) ([]int, bool) {
+	if len(rates) == 0 {
+		return nil, false
+	}
+	altered := false
+	out := make([]int, len(rates))
+	for i, v := range rates {
+		if v < 0 {
+			altered = true
+			v = 0
+		}
+		out[i] = v
+	}
+	start := 0
+	for start < len(out) && out[start] == 0 {
+		start++
+	}
+	if start > 0 {
+		altered = true
+	}
+	if start >= len(out) {
+		return nil, altered
+	}
+	return out[start:], altered
+}
+
 func filterIncreasingRates(rates []int) ([]int, bool) {
 	if len(rates) == 0 {
 		return rates, false
@@ -260,61 +291,34 @@ local nowUnix = tonumber(ARGV[numTiers + 2])
 local expireBefore = tonumber(ARGV[numTiers + 3])
 local memberID = ARGV[numTiers + 4]
 
-local lastTierIdx = numTiers
-
 -- Clean up expired members from all tiers
 for i = 1, numTiers do
     redis.call('ZREMRANGEBYSCORE', KEYS[i], '0', expireBefore)
 end
 
--- Phase 1: Find first available tier from tier 0 (highest priority) to last tier
+-- Phase 1: First tier (highest priority) with limit>0 and free capacity wins; acquire only that tier
 local foundTierIdx = nil
 for tierIdx = 1, numTiers do
-    local count = redis.call('ZCARD', KEYS[tierIdx])
-    if count < limits[tierIdx] then
-        foundTierIdx = tierIdx
-        break
+    local lim = limits[tierIdx]
+    if lim > 0 then
+        local count = redis.call('ZCARD', KEYS[tierIdx])
+        if count < lim then
+            foundTierIdx = tierIdx
+            break
+        end
     end
 end
 
--- If no tier is available, reject
 if foundTierIdx == nil then
     return {0, ""}
 end
 
--- Phase 2: Determine which keys to acquire
-local keysToAcquire = {}
 local priority = numTiers - foundTierIdx + 1
 
-if foundTierIdx == lastTierIdx then
-    -- Found tier is the last tier: only acquire last tier
-    keysToAcquire[1] = lastTierIdx
-else
-    -- Found tier is not the last tier: check if last tier is also available
-    local lastTierCount = redis.call('ZCARD', KEYS[lastTierIdx])
-    if lastTierCount < limits[lastTierIdx] then
-        -- Both available: acquire both found tier and last tier
-        keysToAcquire[1] = foundTierIdx
-        keysToAcquire[2] = lastTierIdx
-    else
-        -- Last tier not available: reject
-        return {0, ""}
-    end
-end
+redis.call('ZADD', KEYS[foundTierIdx], nowUnix, memberID)
+redis.call('EXPIRE', KEYS[foundTierIdx], 3600)
 
--- Phase 3: Acquire all required keys
-for i = 1, #keysToAcquire do
-    local keyIdx = keysToAcquire[i]
-    redis.call('ZADD', KEYS[keyIdx], nowUnix, memberID)
-    redis.call('EXPIRE', KEYS[keyIdx], 3600)
-end
-
--- Build acquired keys indices string
-local acquiredKeysStr = ""
-for i = 1, #keysToAcquire do
-    acquiredKeysStr = acquiredKeysStr .. tostring(keysToAcquire[i] - 1)
-end
-
+local acquiredKeysStr = tostring(foundTierIdx - 1)
 return {priority, acquiredKeysStr}
 `
 

--- a/pkg/engines/limiter/concurrency_color_marker_test.go
+++ b/pkg/engines/limiter/concurrency_color_marker_test.go
@@ -111,10 +111,9 @@ func TestNormalizeConcurrencyMarkerRates(t *testing.T) {
 		wantAltered bool
 	}{
 		{name: "empty", in: nil, wantOut: nil, wantAltered: false},
-		{name: "all_zero_disabled", in: []int{0, 0}, wantOut: nil, wantAltered: true},
-		{name: "trim_leading_zeros", in: []int{0, 0, 3, 2, 1}, wantOut: []int{3, 2, 1}, wantAltered: true},
-		// -1→0 then leading zeros trimmed (same as [0,3] → [3])
-		{name: "negative_as_zero", in: []int{-1, 3}, wantOut: []int{3}, wantAltered: true},
+		{name: "all_zero_kept", in: []int{0, 0}, wantOut: []int{0, 0}, wantAltered: false},
+		{name: "leading_zeros_kept", in: []int{0, 0, 3, 2, 1}, wantOut: []int{0, 0, 3, 2, 1}, wantAltered: false},
+		{name: "negative_as_zero", in: []int{-1, 3}, wantOut: []int{0, 3}, wantAltered: true},
 		{name: "middle_zeros_kept", in: []int{3, 0, 0}, wantOut: []int{3, 0, 0}, wantAltered: false},
 		{name: "arbitrary_order_ok", in: []int{1, 3, 2, 10}, wantOut: []int{1, 3, 2, 10}, wantAltered: false},
 	}
@@ -147,10 +146,11 @@ func TestNewConcurrencyColorMarkerEngine_ValidationAndFiltering(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []int{1, 3, 2, 10}, e.rates)
 
-	// only zeros / negatives -> disabled
+	// only zeros / negatives -> enabled; every tier has limit 0 so nothing is admitted
 	e, err = NewConcurrencyColorMarkerEngine(nil, "k", []int{0, 0, -3}, time.Second, "ns", next)
 	assert.NoError(t, err)
-	assert.Nil(t, e.rates)
+	assert.Equal(t, []int{0, 0, 0}, e.rates)
+	assert.NotNil(t, e.acquireScript)
 }
 
 func TestConcurrencyColorMarker_PassThroughWhenDisabled(t *testing.T) {

--- a/pkg/engines/limiter/concurrency_color_marker_test.go
+++ b/pkg/engines/limiter/concurrency_color_marker_test.go
@@ -103,6 +103,30 @@ func (p *priorityCaptureEngine) Process(req *octollm.Request) (*octollm.Response
 	return p.resp, nil
 }
 
+func TestNormalizeConcurrencyMarkerRates(t *testing.T) {
+	tests := []struct {
+		name       string
+		in         []int
+		wantOut    []int
+		wantAltered bool
+	}{
+		{name: "empty", in: nil, wantOut: nil, wantAltered: false},
+		{name: "all_zero_disabled", in: []int{0, 0}, wantOut: nil, wantAltered: true},
+		{name: "trim_leading_zeros", in: []int{0, 0, 3, 2, 1}, wantOut: []int{3, 2, 1}, wantAltered: true},
+		// -1→0 then leading zeros trimmed (same as [0,3] → [3])
+		{name: "negative_as_zero", in: []int{-1, 3}, wantOut: []int{3}, wantAltered: true},
+		{name: "middle_zeros_kept", in: []int{3, 0, 0}, wantOut: []int{3, 0, 0}, wantAltered: false},
+		{name: "arbitrary_order_ok", in: []int{1, 3, 2, 10}, wantOut: []int{1, 3, 2, 10}, wantAltered: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, altered := normalizeConcurrencyMarkerRates(tt.in)
+			assert.Equal(t, tt.wantOut, got)
+			assert.Equal(t, tt.wantAltered, altered)
+		})
+	}
+}
+
 func TestNewConcurrencyColorMarkerEngine_ValidationAndFiltering(t *testing.T) {
 	next := &nextStubEngine{}
 
@@ -118,10 +142,15 @@ func TestNewConcurrencyColorMarkerEngine_ValidationAndFiltering(t *testing.T) {
 	_, err = NewConcurrencyColorMarkerEngine(nil, "k", []int{1}, 0, "ns", next)
 	assert.Error(t, err)
 
-	// rates that break non-decreasing order get filtered (stop at first decrease)
+	// non-monotonic values are kept (independent per-tier caps)
 	e, err = NewConcurrencyColorMarkerEngine(nil, "k", []int{1, 3, 2, 10}, time.Second, "ns", next)
 	assert.NoError(t, err)
-	assert.Equal(t, []int{1, 3}, e.rates)
+	assert.Equal(t, []int{1, 3, 2, 10}, e.rates)
+
+	// only zeros / negatives -> disabled
+	e, err = NewConcurrencyColorMarkerEngine(nil, "k", []int{0, 0, -3}, time.Second, "ns", next)
+	assert.NoError(t, err)
+	assert.Nil(t, e.rates)
 }
 
 func TestConcurrencyColorMarker_PassThroughWhenDisabled(t *testing.T) {
@@ -145,8 +174,8 @@ func TestConcurrencyColorMarker_PriorityAssignmentAndExhaustion(t *testing.T) {
 	ns := "marker-ns"
 	next := &priorityCaptureEngine{ns: ns}
 
-	// rates=[1,2] => first acquires tier0+tier1 => priority=1; second acquires tier1 only => priority=0; third denied
-	e, err := NewConcurrencyColorMarkerEngine(client, "marker-key", []int{1, 2}, 10*time.Second, ns, next)
+	// rates=[1,1] => two independent slots (p1 then p0); third denied
+	e, err := NewConcurrencyColorMarkerEngine(client, "marker-key", []int{1, 1}, 10*time.Second, ns, next)
 	assert.NoError(t, err)
 
 	resp1, err := e.Process(newConcurrencyColorMarkerTestRequest(t))
@@ -169,7 +198,7 @@ func TestConcurrencyColorMarker_PriorityAssignmentAndExhaustion(t *testing.T) {
 	assert.NoError(t, resp2.Body.Close())
 }
 
-// [3,3]: asserts every allowed request is colored priority 1, then the next is rejected when both tiers are full.
+// [3,0]: three slots at highest priority only; fourth rejected.
 func TestConcurrencyColorMarker_EqualTierLimits_AllPriority1(t *testing.T) {
 	t.Parallel()
 	mr := miniredis.RunT(t)
@@ -179,7 +208,7 @@ func TestConcurrencyColorMarker_EqualTierLimits_AllPriority1(t *testing.T) {
 	ns := "marker-ns-eq33"
 	next := &priorityCaptureEngine{ns: ns}
 
-	e, err := NewConcurrencyColorMarkerEngine(client, "marker-key-eq33", []int{3, 3}, 10*time.Second, ns, next)
+	e, err := NewConcurrencyColorMarkerEngine(client, "marker-key-eq33", []int{3, 0}, 10*time.Second, ns, next)
 	assert.NoError(t, err)
 
 	var resps []*octollm.Response
@@ -197,6 +226,49 @@ func TestConcurrencyColorMarker_EqualTierLimits_AllPriority1(t *testing.T) {
 	assert.Equal(t, 3, next.callCount, "denied request must not reach next")
 
 	for _, r := range resps {
+		assert.NoError(t, r.Body.Close())
+	}
+}
+
+func TestConcurrencyColorMarker_Bands321And300(t *testing.T) {
+	t.Parallel()
+	mr := miniredis.RunT(t)
+	defer mr.Close()
+
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	ns := "marker-ns-bands"
+	next := &priorityCaptureEngine{ns: ns}
+
+	e, err := NewConcurrencyColorMarkerEngine(client, "marker-key-bands", []int{3, 2, 1}, 10*time.Second, ns, next)
+	assert.NoError(t, err)
+
+	want := []int{2, 2, 2, 1, 1, 0}
+	var resps []*octollm.Response
+	for i, pr := range want {
+		resp, err := e.Process(newConcurrencyColorMarkerTestRequest(t))
+		assert.NoError(t, err, "slot %d", i+1)
+		assert.Equal(t, pr, next.lastPriority)
+		resps = append(resps, resp)
+	}
+	_, err = e.Process(newConcurrencyColorMarkerTestRequest(t))
+	assert.ErrorIs(t, err, ErrRateLimitReached)
+	for _, r := range resps {
+		assert.NoError(t, r.Body.Close())
+	}
+
+	next2 := &priorityCaptureEngine{ns: ns}
+	e2, err := NewConcurrencyColorMarkerEngine(client, "marker-key-300", []int{3, 0, 0}, 10*time.Second, ns, next2)
+	assert.NoError(t, err)
+	var resps2 []*octollm.Response
+	for i := 0; i < 3; i++ {
+		resp, err := e2.Process(newConcurrencyColorMarkerTestRequest(t))
+		assert.NoError(t, err)
+		assert.Equal(t, 2, next2.lastPriority, "req %d", i+1)
+		resps2 = append(resps2, resp)
+	}
+	_, err = e2.Process(newConcurrencyColorMarkerTestRequest(t))
+	assert.ErrorIs(t, err, ErrRateLimitReached)
+	for _, r := range resps2 {
 		assert.NoError(t, r.Body.Close())
 	}
 }

--- a/pkg/engines/limiter/request_color_limiter.go
+++ b/pkg/engines/limiter/request_color_limiter.go
@@ -18,7 +18,7 @@ import (
 type RequestColorLimiterEngine struct {
 	redisClient           *redis.Client
 	keyPrefix             string        // Redis key prefix for storing token bucket states
-	limits                []int         // Request limits for each supported priority tier (must be non-increasing)
+	limits                []int         // Built from total + per-priority rates (see NewRequestColorLimiterEngine)
 	rates                 []float64     // Token refill rates for each priority tier (calculated from limits and window)
 	ttls                  []int64       // Redis key TTL in seconds per tier; when expired, bucket is guaranteed full
 	window                time.Duration // Time window
@@ -32,52 +32,26 @@ var _ octollm.Engine = (*RequestColorLimiterEngine)(nil)
 
 var ErrRequestLimitReached = errors.New("request limit reached")
 
-// NewRequestColorLimiterEngine creates a multi-tier token bucket-based priority rate limiter
-// redisClient: Redis client
-// keyPrefix: Redis key prefix for storing token bucket states (each tier uses keyPrefix:tier_N)
-// limits: Request limit array for each supported priority tier (must be non-increasing), e.g., [200, 100, 50]
+// NewRequestColorLimiterEngine creates a multi-tier token bucket-based priority rate limiter.
 //
-//	means this limiter supports priority 2, 1, 0
-//	tier 0 (priority 2): 200 requests, tier 1 (priority 1): 100 requests, tier 2 (priority 0): 50 requests within the window
+// totalConcurrency is the global request budget in the window for the highest-priority tier (YAML `rpm` / total cap).
+// perPriorityRates are per-band budgets below that (YAML `rpm_rates` or equivalent); values greater than or equal to
+// totalConcurrency are effectively capped by the global tier. Negative entries are treated as 0 (empty band).
 //
-// window: Time window (supports seconds, minutes, etc.), must be greater than 0
-// nameSpace: Namespace for isolating priority across different namespaces, marker and limiter within the same nameSpace can communicate
-// next: Next engine
+// Same assembly rules as NewConcurrencyColorLimiterEngine: only total → [total]; only rates with total≤0 → tier 0 = sum(rates);
+// both → [total, ...rates]; empty → disabled.
 //
-// Working principle:
-// - The number of limits determines how many priority levels are supported
-// - Priority mapping: priority = len(limits) - 1 - tierIdx (same as marker)
-// - Token consumption logic:
-//   - Max priority requests (tier 0): only consume from tier 0
-//   - Lower priority requests: atomically consume from own tier and tier 0 with reservation
-//   - Reservation mechanism: when consuming tier 0 tokens, reserve N tokens where N = priority difference
-//     This ensures higher priority requests always have tokens available
-//   - Atomic operation: uses a single Lua script to check both buckets and consume from both or neither
-//     No rollback needed as the operation is atomic
-//
-// Example 1: limits=[200, 100], window=1*time.Minute (supports priority 1, 0)
-// - Tier 0: 200 req/min → Priority 1 (highest supported)
-// - Tier 1: 100 req/min → Priority 0 (lowest)
-// - Priority 1 request: only consume from tier 0
-// - Priority 0 request: atomically check tier 1 ≥1 AND tier 0 >1, then consume from both
-//   - If tier 0 has ≤1 tokens, priority 0 is rejected (reserved for priority 1)
-//
-// Example 2: limits=[200, 100, 50], window=1*time.Minute (supports priority 2, 1, 0)
-// - Tier 0: 200 req/min → Priority 2 (highest supported)
-// - Tier 1: 100 req/min → Priority 1 (medium)
-// - Tier 2: 50 req/min → Priority 0 (lowest)
-// - Priority 2 request: only consume from tier 0
-// - Priority 1 request: atomically check tier 1 ≥1 AND tier 0 >1, then consume from both
-//   - If tier 0 has ≤1 tokens, priority 1 is rejected
-//
-// - Priority 0 request: atomically check tier 2 ≥1 AND tier 0 >2, then consume from both
-//   - If tier 0 has ≤2 tokens, priority 0 is rejected
-func NewRequestColorLimiterEngine(redisClient *redis.Client, keyPrefix string, limits []int, window time.Duration, nameSpace string, next octollm.Engine) (*RequestColorLimiterEngine, error) {
+// window: Time window for token refill, must be greater than 0 when enabled.
+// Lua scripts are unchanged; internal limits slice is built at construction time.
+func NewRequestColorLimiterEngine(redisClient *redis.Client, keyPrefix string, totalConcurrency int, perPriorityRates []int, window time.Duration, nameSpace string, next octollm.Engine) (*RequestColorLimiterEngine, error) {
 	if next == nil {
 		return nil, fmt.Errorf("next engine must not be nil")
 	}
 
-	// If limits is empty, disable rate limiting (pass through)
+	limits, err := buildTotalPlusPerPriorityLimits(totalConcurrency, perPriorityRates)
+	if err != nil {
+		return nil, err
+	}
 	if len(limits) == 0 {
 		return &RequestColorLimiterEngine{
 			redisClient:           redisClient,
@@ -93,20 +67,18 @@ func NewRequestColorLimiterEngine(redisClient *redis.Client, keyPrefix string, l
 		}, nil
 	}
 
-	// Validate and filter limits to ensure non-increasing order
-	filteredLimits, filtered := filterDecreasingRates(limits)
-	if filtered {
-		slog.Warn(fmt.Sprintf("request_color_limiter_limits must be non-increasing, filtered from %v to %v (removed %d invalid suffix values)", limits, filteredLimits, len(limits)-len(filteredLimits)))
-	}
-
 	if window <= 0 {
 		return nil, fmt.Errorf("window must be positive")
 	}
 
-	// Calculate rate and TTL for each tier
-	rates := make([]float64, len(filteredLimits))
-	ttls := make([]int64, len(filteredLimits))
-	for i, limit := range filteredLimits {
+	rates := make([]float64, len(limits))
+	ttls := make([]int64, len(limits))
+	for i, limit := range limits {
+		if limit <= 0 {
+			rates[i] = 0
+			ttls[i] = 1
+			continue
+		}
 		rates[i] = float64(limit) / window.Seconds()
 		ttlSec := int64(math.Ceil(float64(limit)/rates[i])) + 1
 		if ttlSec < 1 {
@@ -118,7 +90,7 @@ func NewRequestColorLimiterEngine(redisClient *redis.Client, keyPrefix string, l
 	return &RequestColorLimiterEngine{
 		redisClient:           redisClient,
 		keyPrefix:             keyPrefix,
-		limits:                filteredLimits,
+		limits:                limits,
 		rates:                 rates,
 		ttls:                  ttls,
 		window:                window,

--- a/pkg/engines/limiter/request_color_limiter_test.go
+++ b/pkg/engines/limiter/request_color_limiter_test.go
@@ -29,30 +29,34 @@ func TestNewRequestColorLimiterEngine_Validation(t *testing.T) {
 	next := &nextStubEngine{}
 
 	// next must not be nil
-	_, err := NewRequestColorLimiterEngine(nil, "k", []int{100}, time.Minute, "ns", nil)
+	_, err := NewRequestColorLimiterEngine(nil, "k", 100, nil, time.Minute, "ns", nil)
 	assert.Error(t, err)
 
-	// empty limits -> disabled (pass-through)
-	e, err := NewRequestColorLimiterEngine(nil, "k", nil, time.Minute, "ns", next)
+	// empty -> disabled (pass-through)
+	e, err := NewRequestColorLimiterEngine(nil, "k", 0, nil, time.Minute, "ns", next)
 	assert.NoError(t, err)
 	assert.Nil(t, e.limits)
 	assert.Nil(t, e.ttls)
 
 	// window must be positive
-	_, err = NewRequestColorLimiterEngine(nil, "k", []int{100}, 0, "ns", next)
+	_, err = NewRequestColorLimiterEngine(nil, "k", 100, nil, 0, "ns", next)
 	assert.Error(t, err)
 
-	// valid config
-	e, err = NewRequestColorLimiterEngine(nil, "k", []int{200, 100, 50}, time.Minute, "ns", next)
+	// valid: total + per-priority -> [200,100,50]
+	e, err = NewRequestColorLimiterEngine(nil, "k", 200, []int{100, 50}, time.Minute, "ns", next)
 	assert.NoError(t, err)
-	assert.Len(t, e.limits, 3)
+	assert.Equal(t, []int{200, 100, 50}, e.limits)
 	assert.Len(t, e.ttls, 3)
+
+	e, err = NewRequestColorLimiterEngine(nil, "k", 100, []int{100}, time.Minute, "ns", next)
+	assert.NoError(t, err)
+	assert.Equal(t, []int{100, 100}, e.limits)
 }
 
 func TestRequestColorLimiter_PassThroughWhenDisabled(t *testing.T) {
 	next := &nextStubEngine{}
 
-	e, err := NewRequestColorLimiterEngine(nil, "k", nil, time.Minute, "ns", next)
+	e, err := NewRequestColorLimiterEngine(nil, "k", 0, nil, time.Minute, "ns", next)
 	assert.NoError(t, err)
 
 	req := newRequestColorLimiterTestRequest(t, "ns", 0)
@@ -73,7 +77,7 @@ func TestRequestColorLimiter_PriorityInContext(t *testing.T) {
 
 	// limits=[5, 3, 2]: tier 0=5, tier 1=3, tier 2=2. All share tier 0.
 	// Use separate keyPrefix per test to isolate (tier 0 is shared within same keyPrefix)
-	e, err := NewRequestColorLimiterEngine(client, "limiter-p2", []int{5, 3, 2}, time.Minute, ns, next)
+	e, err := NewRequestColorLimiterEngine(client, "limiter-p2", 5, []int{3, 2}, time.Minute, ns, next)
 	assert.NoError(t, err)
 
 	// Priority 2 (tier 0 only): 5 requests allowed
@@ -93,7 +97,7 @@ func TestRequestColorLimiter_PriorityInContext(t *testing.T) {
 	assert.Equal(t, 5, next.callCount)
 
 	// Priority 1: use fresh engine/keyPrefix so tier 0 has tokens
-	e1, _ := NewRequestColorLimiterEngine(client, "limiter-p1", []int{5, 3, 2}, time.Minute, ns, next)
+	e1, _ := NewRequestColorLimiterEngine(client, "limiter-p1", 5, []int{3, 2}, time.Minute, ns, next)
 	for i := 0; i < 3; i++ {
 		req := newRequestColorLimiterTestRequest(t, ns, 1)
 		resp, err := e1.Process(req)
@@ -108,7 +112,7 @@ func TestRequestColorLimiter_PriorityInContext(t *testing.T) {
 	assert.Equal(t, 8, next.callCount)
 
 	// Priority 0: use fresh engine/keyPrefix
-	e0, _ := NewRequestColorLimiterEngine(client, "limiter-p0", []int{5, 3, 2}, time.Minute, ns, next)
+	e0, _ := NewRequestColorLimiterEngine(client, "limiter-p0", 5, []int{3, 2}, time.Minute, ns, next)
 	for i := 0; i < 2; i++ {
 		req := newRequestColorLimiterTestRequest(t, ns, 0)
 		resp, err := e0.Process(req)
@@ -132,15 +136,15 @@ func TestRequestColorLimiter_MarkerChain(t *testing.T) {
 	next := &nextStubEngine{}
 	ns := "chain-ns"
 
-	// Marker: limits=[2, 5, 10]. Limiter: limits=[10, 5, 2], shared tier 0.
-	// 8 pass: 2 p2 + 3 p1 + 2 p0 (limiter tier0 and tier2 constrain p0 to 2)
-	limiter, err := NewRequestColorLimiterEngine(client, "chain-limiter", []int{10, 5, 2}, time.Minute, ns, next)
+	// Marker: independent tiers [2, 5, 10]. Limiter: [10, 5, 2].
+	// 8 pass: 2 p2 + 5 p1 + 1 p0 (second p0 blocked by limiter tier0 reservation)
+	limiter, err := NewRequestColorLimiterEngine(client, "chain-limiter", 10, []int{5, 2}, time.Minute, ns, next)
 	assert.NoError(t, err)
 
 	marker, err := NewRequestColorMarkerEngine(client, "chain-marker", []int{2, 5, 10}, time.Minute, ns, limiter)
 	assert.NoError(t, err)
 
-	// Expect 8 through: 2 p2 + 3 p1 + 2 p0 (limiter tier0 and tier2 constrain p0 to 2)
+	// Expect 8 through: 2 p2 + 5 p1 + 1 p0
 	for i := 0; i < 8; i++ {
 		req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://example.com", strings.NewReader("body"))
 		r := octollm.NewRequest(req, octollm.APIFormatUnknown)
@@ -150,7 +154,7 @@ func TestRequestColorLimiter_MarkerChain(t *testing.T) {
 	}
 	assert.Equal(t, 8, next.callCount)
 
-	// 9th: marker may allow (tier 2 has 3 left) but limiter rejects; or marker rejects
+	// 9th: marker still has p0 tokens but limiter rejects
 	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://example.com", strings.NewReader("body"))
 	r := octollm.NewRequest(req, octollm.APIFormatUnknown)
 	_, err = marker.Process(r)
@@ -166,7 +170,7 @@ func TestRequestColorLimiter_NoPriorityDefaultsToLowest(t *testing.T) {
 	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
 	next := &nextStubEngine{}
 
-	e, err := NewRequestColorLimiterEngine(client, "limiter-noprio", []int{10, 2}, time.Minute, "ns", next)
+	e, err := NewRequestColorLimiterEngine(client, "limiter-noprio", 10, []int{2}, time.Minute, "ns", next)
 	assert.NoError(t, err)
 
 	// Request without priority in context -> defaults to priority 0 (lowest tier, 2 requests)

--- a/pkg/engines/limiter/request_color_marker.go
+++ b/pkg/engines/limiter/request_color_marker.go
@@ -33,8 +33,8 @@ var _ octollm.Engine = (*RequestColorMarkerEngine)(nil)
 // keyPrefix: Redis key prefix for storing token bucket states (each tier uses keyPrefix:tier_N)
 // limits: Per-priority request budget within the window, highest priority first. Each positive entry is an
 // independent token-bucket burst; total steady burst capacity is the sum of positive limits.
-// Negative values are treated as 0. Leading zeros are trimmed. Zeros after the first positive entry mean
-// that band has no quota (skipped).
+// Negative values are treated as 0. Only an empty limits slice disables the marker (pass-through).
+// A zero entry at any index means that band has no quota (skipped); e.g. limits=[0] rejects all traffic.
 //
 //	Priority is: len(limits) - 1 - tierIdx (tier 0 = highest priority).
 //

--- a/pkg/engines/limiter/request_color_marker.go
+++ b/pkg/engines/limiter/request_color_marker.go
@@ -17,7 +17,7 @@ import (
 type RequestColorMarkerEngine struct {
 	redisClient       *redis.Client
 	keyPrefix         string        // Redis key prefix for storing token bucket states
-	limits            []int         // Request limits for each priority tier (must be non-decreasing)
+	limits            []int         // Per-priority request budget per window (independent tiers; see NewRequestColorMarkerEngine)
 	rates             []float64     // Token refill rates for each priority tier (calculated from limits and window)
 	ttls              []int64       // Redis key TTL in seconds per tier; when expired, bucket is guaranteed full
 	window            time.Duration // Time window
@@ -31,36 +31,24 @@ var _ octollm.Engine = (*RequestColorMarkerEngine)(nil)
 // NewRequestColorMarkerEngine creates a multi-tier token bucket-based request rate limiter with priority marking
 // redisClient: Redis client
 // keyPrefix: Redis key prefix for storing token bucket states (each tier uses keyPrefix:tier_N)
-// limits: Request limit array for each priority tier (must be non-decreasing), e.g., [10, 50, 100]
+// limits: Per-priority request budget within the window, highest priority first. Each positive entry is an
+// independent token-bucket burst; total steady burst capacity is the sum of positive limits.
+// Negative values are treated as 0. Leading zeros are trimmed. Zeros after the first positive entry mean
+// that band has no quota (skipped).
 //
-//	means tier 0 allows 10 requests, tier 1 allows 50 requests, tier 2 allows 100 requests within the window
-//	Priority is calculated as: len(limits) - 1 - tierIdx
-//	So tier 0 → priority 2 (highest), tier 1 → priority 1, tier 2 → priority 0 (lowest)
+//	Priority is: len(limits) - 1 - tierIdx (tier 0 = highest priority).
 //
 // window: Time window (supports seconds, minutes, etc.), must be greater than 0
 // nameSpace: Namespace for isolating priority across different namespaces, marker and limiter within the same nameSpace can communicate
 // next: Next engine
 //
 // Working principle:
-// - Each tier has its own token bucket with a specific limit and refill rate
-// - Priority number: larger = higher priority (priority 2 > priority 1 > priority 0)
-// - When a request comes in, it tries to consume a token from tier 0 (smallest limit, highest priority) first
-// - Occupancy rule:
-//   - If acquired from tier 0 (highest priority): occupies tier 0 and last tier (lowest priority tier)
-//   - If acquired from tier 1: occupies tier 1 and last tier
-//   - If acquired from last tier (lowest priority): only occupies last tier
+// - Each tier has its own token bucket: rate = limit / window.Seconds(), burst = limit
+// - A request tries tier 0, then tier 1, …; the first tier with burst>0 and at least one token wins
+// - Only that tier’s bucket is decremented
 //
-// - If tier 0 fails, it tries tier 1, and so on
-// - If all tiers fail, the request is rejected
-// - The rate for each tier is calculated as: rate = limit / window.Seconds()
-//
-// Example: limits=[10, 50, 100], window=1*time.Minute
-// - Tier 0: 10 requests/min, rate=10/60≈0.167 tokens/sec → Priority 2 (highest)
-// - Tier 1: 50 requests/min, rate=50/60≈0.833 tokens/sec → Priority 1 (medium)
-// - Tier 2: 100 requests/min, rate=100/60≈1.667 tokens/sec → Priority 0 (lowest)
-// - Request tries tier 0 first: if available, occupies tier 0 and tier 2 → Priority 2
-// - If tier 0 full, tries tier 1: if available, occupies tier 1 and tier 2 → Priority 1
-// - If tier 1 full, tries tier 2: if available, occupies tier 2 only → Priority 0
+// Example: limits=[3, 2, 1], window=1m → up to 3+2+1 marked requests per minute at priorities 2, 1, 0 respectively
+// Example: limits=[3, 0, 0] → three highest-priority tokens per window; lower bands empty
 func NewRequestColorMarkerEngine(redisClient *redis.Client, keyPrefix string, limits []int, window time.Duration, nameSpace string, next octollm.Engine) (*RequestColorMarkerEngine, error) {
 	if next == nil {
 		return nil, fmt.Errorf("next engine must not be nil")
@@ -81,10 +69,22 @@ func NewRequestColorMarkerEngine(redisClient *redis.Client, keyPrefix string, li
 		}, nil
 	}
 
-	// Validate and filter limits to ensure non-decreasing order
-	filteredLimits, filtered := filterIncreasingRates(limits)
-	if filtered {
-		slog.Warn(fmt.Sprintf("request_color_marker_limits must be non-decreasing, filtered from %v to %v (removed %d invalid suffix values)", limits, filteredLimits, len(limits)-len(filteredLimits)))
+	normalizedLimits, normalized := normalizeConcurrencyMarkerRates(limits)
+	if normalized {
+		slog.Warn(fmt.Sprintf("request_color_marker_limits normalized from %v to %v", limits, normalizedLimits))
+	}
+	if len(normalizedLimits) == 0 {
+		return &RequestColorMarkerEngine{
+			redisClient:       redisClient,
+			keyPrefix:         keyPrefix,
+			limits:            nil,
+			rates:             nil,
+			ttls:              nil,
+			window:            0,
+			nameSpace:         nameSpace,
+			tokenBucketScript: nil,
+			next:              next,
+		}, nil
 	}
 
 	if window <= 0 {
@@ -92,9 +92,14 @@ func NewRequestColorMarkerEngine(redisClient *redis.Client, keyPrefix string, li
 	}
 
 	// Calculate rate and TTL for each tier
-	rates := make([]float64, len(filteredLimits))
-	ttls := make([]int64, len(filteredLimits))
-	for i, limit := range filteredLimits {
+	rates := make([]float64, len(normalizedLimits))
+	ttls := make([]int64, len(normalizedLimits))
+	for i, limit := range normalizedLimits {
+		if limit <= 0 {
+			rates[i] = 0
+			ttls[i] = 1
+			continue
+		}
 		rates[i] = float64(limit) / window.Seconds()
 		ttlSec := int64(math.Ceil(float64(limit)/rates[i])) + 1
 		if ttlSec < 1 {
@@ -106,7 +111,7 @@ func NewRequestColorMarkerEngine(redisClient *redis.Client, keyPrefix string, li
 	return &RequestColorMarkerEngine{
 		redisClient:       redisClient,
 		keyPrefix:         keyPrefix,
-		limits:            filteredLimits,
+		limits:            normalizedLimits,
 		rates:             rates,
 		ttls:              ttls,
 		window:            window,
@@ -229,8 +234,6 @@ for i = 1, numTiers do
     ttls[i] = tonumber(ARGV[2*numTiers + 2 + i])
 end
 
-local lastTierIdx = numTiers
-
 -- Helper function to get bucket tokens
 local function getBucketTokens(keyIdx)
     local bucket = redis.call('HMGET', KEYS[keyIdx], 'tokens', 'lastRefill')
@@ -250,62 +253,28 @@ local function updateBucket(keyIdx, tokens)
     redis.call('EXPIRE', KEYS[keyIdx], ttls[keyIdx])
 end
 
--- Phase 1: Find first available tier from tier 0 (highest priority) to last tier
+-- Phase 1: First tier with burst>=1 and at least one token wins; consume only that bucket
 local foundTierIdx = nil
-local tiersTokens = {}
+local foundTokens = nil
 
 for tierIdx = 1, numTiers do
-    local tokens = getBucketTokens(tierIdx)
-    tiersTokens[tierIdx] = tokens
-    
-    if tokens >= 1 then
-        foundTierIdx = tierIdx
-        break
+    if bursts[tierIdx] >= 1 then
+        local tokens = getBucketTokens(tierIdx)
+        if tokens >= 1 then
+            foundTierIdx = tierIdx
+            foundTokens = tokens
+            break
+        end
     end
 end
 
--- If no tier is available, reject without updating (don't update lastRefill when not consuming)
 if foundTierIdx == nil then
     return {0, ""}
 end
 
--- Phase 2: Determine which keys to consume
-local keysToConsume = {}
 local priority = numTiers - foundTierIdx + 1
+updateBucket(foundTierIdx, foundTokens - 1)
 
-if foundTierIdx == lastTierIdx then
-    -- Found tier is the last tier: only consume last tier
-    keysToConsume[1] = {keyIdx = lastTierIdx, tokens = tiersTokens[lastTierIdx]}
-else
-    -- Found tier is not the last tier: check if last tier also has tokens
-    local lastTierTokens = tiersTokens[lastTierIdx]
-    if lastTierTokens == nil then
-        lastTierTokens = getBucketTokens(lastTierIdx)
-        tiersTokens[lastTierIdx] = lastTierTokens
-    end
-    
-    if lastTierTokens >= 1 then
-        -- Both available: consume both found tier and last tier
-        keysToConsume[1] = {keyIdx = foundTierIdx, tokens = tiersTokens[foundTierIdx]}
-        keysToConsume[2] = {keyIdx = lastTierIdx, tokens = lastTierTokens}
-    else
-        -- Last tier not available: reject without updating (don't update lastRefill when not consuming)
-        return {0, ""}
-    end
-end
-
--- Phase 3: Consume tokens from required buckets (only update lastRefill when consuming)
-for i = 1, #keysToConsume do
-    local keyIdx = keysToConsume[i].keyIdx
-    local tokens = keysToConsume[i].tokens - 1
-    updateBucket(keyIdx, tokens)
-end
-
--- Build acquired keys indices string
-local acquiredKeysStr = ""
-for i = 1, #keysToConsume do
-    acquiredKeysStr = acquiredKeysStr .. tostring(keysToConsume[i].keyIdx - 1)
-end
-
+local acquiredKeysStr = tostring(foundTierIdx - 1)
 return {priority, acquiredKeysStr}
 `

--- a/pkg/engines/limiter/request_color_marker_test.go
+++ b/pkg/engines/limiter/request_color_marker_test.go
@@ -42,6 +42,16 @@ func TestNewRequestColorMarkerEngine_Validation(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, e.limits, 3)
 	assert.Len(t, e.ttls, 3)
+
+	// non-monotonic kept (independent per-tier bursts)
+	e, err = NewRequestColorMarkerEngine(nil, "k", []int{10, 5, 20}, time.Minute, "ns", next)
+	assert.NoError(t, err)
+	assert.Equal(t, []int{10, 5, 20}, e.limits)
+
+	// only zeros / negatives -> disabled
+	e, err = NewRequestColorMarkerEngine(nil, "k", []int{0, 0, -1}, time.Minute, "ns", next)
+	assert.NoError(t, err)
+	assert.Nil(t, e.limits)
 }
 
 func TestRequestColorMarker_PassThroughWhenDisabled(t *testing.T) {
@@ -65,12 +75,10 @@ func TestRequestColorMarker_MultiTier_AcquirePriority(t *testing.T) {
 	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
 	next := &nextStubEngine{}
 
-	// limits=[2, 5, 10]: tier 0 allows 2, tier 1 allows 5, tier 2 allows 10
-	// tier 0 + tier 2 consumed together when from tier 0; tier 1 + tier 2 when from tier 1; tier 2 only when from tier 2
+	// limits=[2, 5, 10]: independent bursts per tier; 2+5+10 = 17 requests before exhaustion at t=0
 	e, err := NewRequestColorMarkerEngine(client, "marker-test", []int{2, 5, 10}, time.Minute, "ns", next)
 	assert.NoError(t, err)
 
-	// First 2 requests: acquire from tier 0 -> priority 2
 	for i := 0; i < 2; i++ {
 		req := newRequestColorMarkerTestRequest(t)
 		resp, err := e.Process(req)
@@ -79,31 +87,28 @@ func TestRequestColorMarker_MultiTier_AcquirePriority(t *testing.T) {
 	}
 	assert.Equal(t, 2, next.callCount)
 
-	// Next 3 requests: tier 0 exhausted, acquire from tier 1 -> priority 1
-	for i := 0; i < 3; i++ {
-		req := newRequestColorMarkerTestRequest(t)
-		resp, err := e.Process(req)
-		assert.NoError(t, err)
-		assert.NotNil(t, resp)
-	}
-	assert.Equal(t, 5, next.callCount)
-
-	// Next 5 requests: tier 1 exhausted, acquire from tier 2 only -> priority 0
 	for i := 0; i < 5; i++ {
 		req := newRequestColorMarkerTestRequest(t)
 		resp, err := e.Process(req)
 		assert.NoError(t, err)
 		assert.NotNil(t, resp)
 	}
-	assert.Equal(t, 10, next.callCount)
+	assert.Equal(t, 7, next.callCount)
 
-	// 11th request: all tiers exhausted -> rejected
+	for i := 0; i < 10; i++ {
+		req := newRequestColorMarkerTestRequest(t)
+		resp, err := e.Process(req)
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+	}
+	assert.Equal(t, 17, next.callCount)
+
 	req := newRequestColorMarkerTestRequest(t)
 	resp, err := e.Process(req)
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 	assert.ErrorIs(t, err, ErrRateLimitReached)
-	assert.Equal(t, 10, next.callCount)
+	assert.Equal(t, 17, next.callCount)
 }
 
 func TestRequestColorMarker_RefillOverTime(t *testing.T) {
@@ -114,23 +119,21 @@ func TestRequestColorMarker_RefillOverTime(t *testing.T) {
 	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
 	next := &nextStubEngine{}
 
-	// limits=[2, 4], window=30s: tier 0 rate=2/30, refill 1 token in 15s
+	// limits=[2, 4], window=30s: 6 independent tokens; tier 0 rate=2/30
 	e, err := NewRequestColorMarkerEngine(client, "marker-refill", []int{2, 4}, 30*time.Second, "ns", next)
 	assert.NoError(t, err)
 
-	// Exhaust all 4 (2 from tier 0+tier1, 2 from tier 1+tier1)
-	for i := 0; i < 4; i++ {
+	for i := 0; i < 6; i++ {
 		req := newRequestColorMarkerTestRequest(t)
 		_, err := e.Process(req)
 		assert.NoError(t, err)
 	}
-	assert.Equal(t, 4, next.callCount)
+	assert.Equal(t, 6, next.callCount)
 
-	// 5th rejected
 	req := newRequestColorMarkerTestRequest(t)
 	_, err = e.Process(req)
 	assert.Error(t, err)
-	assert.Equal(t, 4, next.callCount)
+	assert.Equal(t, 6, next.callCount)
 
 	// Wait for refill (~16s for 1 token in tier 0)
 	time.Sleep(18 * time.Second)
@@ -139,5 +142,5 @@ func TestRequestColorMarker_RefillOverTime(t *testing.T) {
 	resp, err := e.Process(req)
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
-	assert.Equal(t, 5, next.callCount)
+	assert.Equal(t, 7, next.callCount)
 }

--- a/pkg/engines/limiter/request_color_marker_test.go
+++ b/pkg/engines/limiter/request_color_marker_test.go
@@ -48,10 +48,11 @@ func TestNewRequestColorMarkerEngine_Validation(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []int{10, 5, 20}, e.limits)
 
-	// only zeros / negatives -> disabled
+	// only zeros / negatives -> enabled; every tier has limit 0 so nothing is admitted
 	e, err = NewRequestColorMarkerEngine(nil, "k", []int{0, 0, -1}, time.Minute, "ns", next)
 	assert.NoError(t, err)
-	assert.Nil(t, e.limits)
+	assert.Equal(t, []int{0, 0, 0}, e.limits)
+	assert.NotNil(t, e.tokenBucketScript)
 }
 
 func TestRequestColorMarker_PassThroughWhenDisabled(t *testing.T) {

--- a/pkg/engines/load-balancer/shard_key_concurrency_test.go
+++ b/pkg/engines/load-balancer/shard_key_concurrency_test.go
@@ -62,7 +62,8 @@ func buildBackendWithLimiter(t *testing.T, rd *redis.Client, cfg backendConfig) 
 	engine, err := limiter.NewConcurrencyColorLimiterEngine(
 		rd,
 		"concurrency_rate:service:gpt-4:"+cfg.svcName,
-		[]int{cfg.rate},
+		cfg.rate,
+		nil,
 		time.Minute,
 		"",
 		next,


### PR DESCRIPTION
- ConcurrencyColorLimiterEngine: take totalConcurrency and perPriorityRates; build internal tiers (flat cap, unbounded tier-0 when only per-band, or both).
- Color markers (concurrency/request): acquire a single tier; per-band caps are independent; normalize rates (clamp negatives, trim leading zeros, empty bands).
- Refresh Lua acquire paths and tests; update shard_key_concurrency limiter ctor.