### PR TITLE
fix: avoid double-close / no-close of upstream resources

### DIFF
--- a/pkg/engines/converter/claude.go
+++ b/pkg/engines/converter/claude.go
@@ -42,12 +42,14 @@ func (e *ChatCompletionToClaudeMessages) Process(req *octollm.Request) (*octollm
 	if resp.Stream != nil {
 		newStream, err := e.convertStreamResponse(req, resp.Stream)
 		if err != nil {
+			resp.Stream.Close()
 			return nil, fmt.Errorf("failed to convert stream response body: %w", err)
 		}
 		resp.Stream = newStream
 	} else {
 		nonStreamResp, err := e.convertNonStreamResponseBody(req.Context(), resp.Body)
 		if err != nil {
+			resp.Body.Close()
 			return nil, fmt.Errorf("failed to convert non-stream response body: %w", err)
 		}
 		resp.Body = nonStreamResp
@@ -321,6 +323,7 @@ func (e *ChatCompletionToClaudeMessages) convertNonStreamResponseBody(ctx contex
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse response body: %w", err)
 	}
+	srcBody.Close()
 
 	openaiResp, ok := parsed.(*openai.ChatCompletionResponse)
 	if !ok {
@@ -409,13 +412,14 @@ func (e *ChatCompletionToClaudeMessages) convertNonStreamResponseBody(ctx contex
 func (e *ChatCompletionToClaudeMessages) convertStreamResponse(req *octollm.Request, src *octollm.StreamChan) (*octollm.StreamChan, error) {
 	inCh := src.Chan()
 	outCh := make(chan *octollm.StreamChunk)
+	ctx, cancel := context.WithCancel(req.Context())
 
 	intPtr := func(i int) *int { return &i }
 
 	octollm.SafeGo(req, func() {
-		ctx := req.Context()
 		defer close(outCh)
 		defer src.Close()
+		defer cancel()
 
 		started := false
 		msgID := ""
@@ -457,7 +461,7 @@ func (e *ChatCompletionToClaudeMessages) convertStreamResponse(req *octollm.Requ
 						Type:  "content_block_stop",
 						Index: intPtr(currentBlockIndex),
 					}
-					if err := e.sendEvent(outCh, blockStop); err != nil {
+					if err := e.sendEvent(ctx, outCh, blockStop); err != nil {
 						slog.ErrorContext(ctx, fmt.Sprintf("failed to send content_block_stop event: %v", err))
 						break
 					}
@@ -489,7 +493,7 @@ func (e *ChatCompletionToClaudeMessages) convertStreamResponse(req *octollm.Requ
 							msgDelta.Usage.CacheReadInputTokens = &cached
 						}
 					}
-					if err := e.sendEvent(outCh, msgDelta); err != nil {
+					if err := e.sendEvent(ctx, outCh, msgDelta); err != nil {
 						slog.ErrorContext(ctx, fmt.Sprintf("failed to send message_delta event: %v", err))
 						break
 					}
@@ -500,7 +504,7 @@ func (e *ChatCompletionToClaudeMessages) convertStreamResponse(req *octollm.Requ
 				msgStop := &anthropic.ClaudeMessagesStreamEvent{
 					Type: "message_stop",
 				}
-				if err := e.sendEvent(outCh, msgStop); err != nil {
+				if err := e.sendEvent(ctx, outCh, msgStop); err != nil {
 					slog.ErrorContext(ctx, fmt.Sprintf("failed to send message_stop event: %v", err))
 				}
 				break
@@ -527,7 +531,7 @@ func (e *ChatCompletionToClaudeMessages) convertStreamResponse(req *octollm.Requ
 						Usage:   &anthropic.Usage{InputTokens: 0, OutputTokens: 0}, // Placeholder
 					},
 				}
-				if err := e.sendEvent(outCh, msgStart); err != nil {
+				if err := e.sendEvent(ctx, outCh, msgStart); err != nil {
 					slog.ErrorContext(ctx, fmt.Sprintf("failed to send message_start event: %v", err))
 					continue
 				}
@@ -580,7 +584,7 @@ func (e *ChatCompletionToClaudeMessages) convertStreamResponse(req *octollm.Requ
 							Type:  "content_block_stop",
 							Index: intPtr(currentBlockIndex),
 						}
-						if err := e.sendEvent(outCh, blockStop); err != nil {
+						if err := e.sendEvent(ctx, outCh, blockStop); err != nil {
 							slog.ErrorContext(ctx, fmt.Sprintf("failed to send content_block_stop event: %v", err))
 							continue
 						}
@@ -601,7 +605,7 @@ func (e *ChatCompletionToClaudeMessages) convertStreamResponse(req *octollm.Requ
 							},
 						},
 					}
-					if err := e.sendEvent(outCh, blockStart); err != nil {
+					if err := e.sendEvent(ctx, outCh, blockStart); err != nil {
 						slog.ErrorContext(ctx, fmt.Sprintf("failed to send content_block_start event: %v", err))
 						continue
 					}
@@ -620,7 +624,7 @@ func (e *ChatCompletionToClaudeMessages) convertStreamResponse(req *octollm.Requ
 				deltaBytes, _ := json.Marshal(deltaData)
 				deltaEvent.DeltaRaw = deltaBytes
 
-				if err := e.sendEvent(outCh, deltaEvent); err != nil {
+				if err := e.sendEvent(ctx, outCh, deltaEvent); err != nil {
 					slog.ErrorContext(ctx, fmt.Sprintf("failed to send content_block_delta event: %v", err))
 					continue
 				}
@@ -646,7 +650,7 @@ func (e *ChatCompletionToClaudeMessages) convertStreamResponse(req *octollm.Requ
 							Type:  "content_block_stop",
 							Index: intPtr(currentBlockIndex),
 						}
-						if err := e.sendEvent(outCh, blockStop); err != nil {
+						if err := e.sendEvent(ctx, outCh, blockStop); err != nil {
 							slog.ErrorContext(ctx, fmt.Sprintf("failed to send content_block_stop event: %v", err))
 							continue
 						}
@@ -665,7 +669,7 @@ func (e *ChatCompletionToClaudeMessages) convertStreamResponse(req *octollm.Requ
 							Text: &emptyText,
 						},
 					}
-					if err := e.sendEvent(outCh, blockStart); err != nil {
+					if err := e.sendEvent(ctx, outCh, blockStart); err != nil {
 						slog.ErrorContext(ctx, fmt.Sprintf("failed to send content_block_start for text event: %v", err))
 						continue
 					}
@@ -684,7 +688,7 @@ func (e *ChatCompletionToClaudeMessages) convertStreamResponse(req *octollm.Requ
 				deltaBytes, _ := json.Marshal(deltaData)
 				deltaEvent.DeltaRaw = deltaBytes
 
-				if err := e.sendEvent(outCh, deltaEvent); err != nil {
+				if err := e.sendEvent(ctx, outCh, deltaEvent); err != nil {
 					slog.ErrorContext(ctx, fmt.Sprintf("failed to send content_block_delta event: %v", err))
 					continue
 				}
@@ -713,7 +717,7 @@ func (e *ChatCompletionToClaudeMessages) convertStreamResponse(req *octollm.Requ
 								Type:  "content_block_stop",
 								Index: intPtr(currentBlockIndex),
 							}
-							if err := e.sendEvent(outCh, blockStop); err != nil {
+							if err := e.sendEvent(ctx, outCh, blockStop); err != nil {
 								slog.ErrorContext(ctx, fmt.Sprintf("failed to send content_block_stop event: %v", err))
 								continue
 							}
@@ -735,7 +739,7 @@ func (e *ChatCompletionToClaudeMessages) convertStreamResponse(req *octollm.Requ
 								},
 							},
 						}
-						if err := e.sendEvent(outCh, blockStart); err != nil {
+						if err := e.sendEvent(ctx, outCh, blockStart); err != nil {
 							slog.ErrorContext(ctx, fmt.Sprintf("failed to send content_block_start for tool_use event: %v", err))
 							continue
 						}
@@ -756,7 +760,7 @@ func (e *ChatCompletionToClaudeMessages) convertStreamResponse(req *octollm.Requ
 						deltaBytes, _ := json.Marshal(deltaData)
 						deltaEvent.DeltaRaw = deltaBytes
 
-						if err := e.sendEvent(outCh, deltaEvent); err != nil {
+						if err := e.sendEvent(ctx, outCh, deltaEvent); err != nil {
 							slog.ErrorContext(ctx, fmt.Sprintf("failed to send input_json_delta event: %v", err))
 							continue
 						}
@@ -766,18 +770,22 @@ func (e *ChatCompletionToClaudeMessages) convertStreamResponse(req *octollm.Requ
 		}
 	})
 
-	newStream := octollm.NewStreamChan(outCh, nil)
+	newStream := octollm.NewStreamChan(outCh, cancel)
 	return newStream, nil
 }
 
-func (e *ChatCompletionToClaudeMessages) sendEvent(ch chan<- *octollm.StreamChunk, event *anthropic.ClaudeMessagesStreamEvent) error {
+func (e *ChatCompletionToClaudeMessages) sendEvent(ctx context.Context, ch chan<- *octollm.StreamChunk, event *anthropic.ClaudeMessagesStreamEvent) error {
 	bytes, err := json.Marshal(event)
 	if err != nil {
 		return fmt.Errorf("failed to marshal claude stream event: %w", err)
 	}
 	body := octollm.NewBodyFromBytes(bytes, &octollm.JSONParser[anthropic.ClaudeMessagesStreamEvent]{})
-	ch <- &octollm.StreamChunk{Body: body, Metadata: map[string]string{"event": event.Type}}
-	return nil
+	select {
+	case ch <- &octollm.StreamChunk{Body: body, Metadata: map[string]string{"event": event.Type}}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 func (e *ChatCompletionToClaudeMessages) mapFinishReason(fr string) string {

--- a/pkg/engines/converter/claude_test.go
+++ b/pkg/engines/converter/claude_test.go
@@ -2,6 +2,8 @@ package converter
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"net/http"
 	"testing"
 
@@ -9,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 
+	"github.com/infinigence/octollm/pkg/internal/testhelper"
 	"github.com/infinigence/octollm/pkg/octollm"
 	"github.com/infinigence/octollm/pkg/types/anthropic"
 	"github.com/infinigence/octollm/pkg/types/openai"
@@ -1598,4 +1601,115 @@ func TestChatCompletionsToClaudeMessages_convertStreamResponse_WithReasoning(t *
 		`{"type": "message_stop"}`,
 	}
 	testChatCompletionsToClaudeMessages_convertStreamResponse(t, openaiResp, exceptClaudeResp)
+}
+
+func TestChatCompletionsToClaudeMessages_Close_Once_NonStream(t *testing.T) {
+	httpReq, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, "/", nil)
+	req := octollm.NewRequest(httpReq, octollm.APIFormatClaudeMessages)
+	req.Body = octollm.NewBodyFromBytes(
+		[]byte(`{"model":"claude-3-5-haiku","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}`),
+		&octollm.JSONParser[anthropic.ClaudeMessagesRequest]{},
+	)
+
+	openaiRespJSON := `{"id":"x","object":"chat.completion","created":1,"model":"m","choices":[{"index":0,"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`
+
+	mockEng := newMockEngine(t)
+	mockEng.responseToReturn = &octollm.Response{
+		StatusCode: 200,
+		Header:     http.Header{},
+		Body: octollm.NewBodyFromBytes(
+			[]byte(openaiRespJSON),
+			&octollm.JSONParser[openai.ChatCompletionResponse]{},
+		),
+	}
+
+	next := testhelper.NewCloseCountingEngine(t, mockEng)
+	converter := NewChatCompletionToClaudeMessages(next)
+
+	resp, err := converter.Process(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp.Body)
+
+	_, err = resp.Body.Bytes()
+	require.NoError(t, err)
+	resp.Body.Close()
+}
+
+// errReader is an io.ReadCloser that fails on the first Read call.
+type errReader struct {
+	closed bool
+}
+
+func (r *errReader) Read(p []byte) (int, error) { return 0, fmt.Errorf("mock read error") }
+func (r *errReader) Close() error               { r.closed = true; return nil }
+
+var _ io.ReadCloser = (*errReader)(nil)
+
+func TestChatCompletionsToClaudeMessages_Close_Once_NonStream_ReadError(t *testing.T) {
+	httpReq, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, "/", nil)
+	req := octollm.NewRequest(httpReq, octollm.APIFormatClaudeMessages)
+	req.Body = octollm.NewBodyFromBytes(
+		[]byte(`{"model":"claude-3-5-haiku","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}`),
+		&octollm.JSONParser[anthropic.ClaudeMessagesRequest]{},
+	)
+
+	mockEng := newMockEngine(t)
+	mockEng.responseToReturn = &octollm.Response{
+		StatusCode: 200,
+		Header:     http.Header{},
+		Body: octollm.NewBodyFromReader(
+			&errReader{},
+			&octollm.JSONParser[openai.ChatCompletionResponse]{},
+		),
+	}
+
+	next := testhelper.NewCloseCountingEngine(t, mockEng)
+	converter := NewChatCompletionToClaudeMessages(next)
+
+	resp, err := converter.Process(req)
+	require.Error(t, err)
+	require.Nil(t, resp)
+}
+
+func TestChatCompletionsToClaudeMessages_Close_Once_Stream(t *testing.T) {
+	httpReq, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, "/", nil)
+	req := octollm.NewRequest(httpReq, octollm.APIFormatClaudeMessages)
+	req.Body = octollm.NewBodyFromBytes(
+		[]byte(`{"model":"claude-3-5-haiku","max_tokens":16,"messages":[{"role":"user","content":"hi"}],"stream":true}`),
+		&octollm.JSONParser[anthropic.ClaudeMessagesRequest]{},
+	)
+
+	openaiChunks := []string{
+		`{"id":"x","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"role":"assistant","content":"hi"},"finish_reason":null}]}`,
+		`{"id":"x","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"content":""},"finish_reason":"stop"}]}`,
+		`[DONE]`,
+	}
+
+	inCh := make(chan *octollm.StreamChunk)
+	go func() {
+		defer close(inCh)
+		for _, c := range openaiChunks {
+			body := octollm.NewBodyFromBytes([]byte(c), &octollm.JSONParser[openai.ChatCompletionStreamChunk]{})
+			inCh <- &octollm.StreamChunk{Body: body}
+		}
+	}()
+	inStream := octollm.NewStreamChan(inCh, func() {})
+
+	mockEng := newMockEngine(t)
+	mockEng.responseToReturn = &octollm.Response{
+		StatusCode: 200,
+		Header:     http.Header{},
+		Stream:     inStream,
+	}
+
+	next := testhelper.NewCloseCountingEngine(t, mockEng)
+	converter := NewChatCompletionToClaudeMessages(next)
+
+	resp, err := converter.Process(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp.Stream)
+
+	for range resp.Stream.Chan() {
+	}
+	resp.Stream.Close()
 }

--- a/pkg/engines/moderator/moderator.go
+++ b/pkg/engines/moderator/moderator.go
@@ -148,13 +148,18 @@ func (e *TextModeratorEngine) Process(req *octollm.Request) (*octollm.Response, 
 		}
 		if moderationSampleHit(e.OutputModerationSampleRate) {
 			if err := e.ModeratorService.Allow(req.Context(), text); err != nil {
+				// GetReplacementBody mutates resp.Body in place and returns the same
+				// *UnifiedBody. On the replacement path the body is still live (handed
+				// back to the caller), so we must not Close it here — that would
+				// double-fire closeFunc. On the no-replacement path the caller never
+				// sees resp, so we Close to release closeFunc ourselves.
 				replacement := e.TextModeratorAdapter.GetReplacementBody(req.Context(), resp.Body)
-				resp.Body.Close()
 				req.SetMetadataValue(isSpamKey, true)
 				if replacement != nil {
 					resp.Body = replacement
 					return resp, nil
 				}
+				resp.Body.Close()
 				return nil, fmt.Errorf("%w: %w", ErrOutputNotAllowed, err)
 			}
 		}
@@ -247,7 +252,6 @@ func (e *TextModeratorEngine) Process(req *octollm.Request) (*octollm.Response, 
 			// get replacement chunk
 			req.SetMetadataValue(isSpamKey, true)
 
-			originalChunks.Close()
 			if len(chunkBuffer) > 0 {
 				replacement := e.TextModeratorAdapter.GetReplacementBody(req.Context(), chunkBuffer[0].Body)
 				if replacement != nil {

--- a/pkg/engines/moderator/moderator_test.go
+++ b/pkg/engines/moderator/moderator_test.go
@@ -229,3 +229,89 @@ func TestModerator_Process_Stream(t *testing.T) {
 		})
 	}
 }
+
+func TestModerator_Close_Once(t *testing.T) {
+	tests := []struct {
+		name           string
+		outputText     string
+		isSpamFunc     func([]rune) bool
+		wantSpam       bool
+		requestBody    string
+		noReplacement  bool
+		wantOutputSpam bool
+	}{
+		{
+			name:        "clean stream closes upstream exactly once",
+			outputText:  "hello world",
+			isSpamFunc:  strContainsFactory("{bad}"),
+			requestBody: `{"model":"glm-4.7","messages":[{"role":"user","content":"hi"}],"stream":true}`,
+		},
+		{
+			name:        "spam stream with replacement closes upstream exactly once",
+			outputText:  "{bad}",
+			isSpamFunc:  strContainsFactory("{bad}"),
+			wantSpam:    true,
+			requestBody: `{"model":"glm-4.7","messages":[{"role":"user","content":"hi"}],"stream":true}`,
+		},
+		{
+			name:        "clean non-stream closes upstream exactly once",
+			outputText:  "hello world",
+			isSpamFunc:  strContainsFactory("{bad}"),
+			requestBody: `{"model":"glm-4.7","messages":[{"role":"user","content":"hi"}],"stream":false}`,
+		},
+		{
+			name:        "spam non-stream with replacement closes upstream exactly once",
+			outputText:  "{bad}",
+			isSpamFunc:  strContainsFactory("{bad}"),
+			wantSpam:    true,
+			requestBody: `{"model":"glm-4.7","messages":[{"role":"user","content":"hi"}],"stream":false}`,
+		},
+		{
+			name:           "spam non-stream without replacement closes upstream exactly once",
+			outputText:     "{bad}",
+			isSpamFunc:     strContainsFactory("{bad}"),
+			requestBody:    `{"model":"glm-4.7","messages":[{"role":"user","content":"hi"}],"stream":false}`,
+			noReplacement:  true,
+			wantOutputSpam: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			next := testhelper.NewCloseCountingEngine(t, mock.NewOpenAIWithFixedOutput(tt.outputText, 0, 0))
+			adapter := adapterWithConfig
+			if tt.noReplacement {
+				adapter = adapterWithoutConfig
+			}
+			eng := &TextModeratorEngine{
+				ModeratorService:     &mockTextModeratorService{isSpamFunc: tt.isSpamFunc, maxRuneLen: 100},
+				TextModeratorAdapter: adapter,
+				ModerateInput:        true,
+				ModerateOutput:       true,
+				Next:                 next,
+			}
+
+			req := testhelper.CreateTestRequest(testhelper.WithBody(tt.requestBody))
+			resp, err := eng.Process(req)
+			if tt.wantOutputSpam {
+				assert.ErrorIs(t, err, ErrOutputNotAllowed)
+				assert.Nil(t, resp)
+				return
+			}
+			assert.NoError(t, err)
+
+			if resp.Body != nil {
+				_, err := resp.Body.Bytes()
+				assert.NoError(t, err)
+				resp.Body.Close()
+			} else {
+				for range resp.Stream.Chan() {
+				}
+				resp.Stream.Close()
+			}
+
+			isSpam, _ := GetIsSpam(req)
+			assert.Equal(t, tt.wantSpam, isSpam)
+		})
+	}
+}

--- a/pkg/engines/rewrite.go
+++ b/pkg/engines/rewrite.go
@@ -203,6 +203,7 @@ func (e *RewriteEngine) Process(req *octollm.Request) (*octollm.Response, error)
 		}
 		b, err := resp.Body.Bytes()
 		if err != nil {
+			resp.Body.Close()
 			return nil, fmt.Errorf("read response body error: %w", err)
 		}
 		resp.Body.SetBytes(respRewriter.RewriteJSON(b))

--- a/pkg/internal/testhelper/helper.go
+++ b/pkg/internal/testhelper/helper.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sync/atomic"
+	"testing"
 	"time"
 
 	"github.com/infinigence/octollm/pkg/exprenv"
@@ -124,6 +126,49 @@ func WithFeature(name string, extractor exprenv.FeatureExtractor) reqOptFunc {
 		}
 		opts.features[name] = extractor
 	}
+}
+
+// CloseCountingEngine wraps an Engine and, via OnClose on the returned
+// stream or body, counts how many times the upstream's closeFunc fires.
+// t.Cleanup asserts the count is exactly one — any test using this
+// constructor automatically gets a once-and-only-once invariant.
+type CloseCountingEngine struct {
+	t          *testing.T
+	inner      octollm.Engine
+	closeCount *int32
+}
+
+func NewCloseCountingEngine(t *testing.T, inner octollm.Engine) *CloseCountingEngine {
+	e := &CloseCountingEngine{
+		t:          t,
+		inner:      inner,
+		closeCount: new(int32),
+	}
+	t.Cleanup(func() {
+		count := atomic.LoadInt32(e.closeCount)
+		if count > 1 {
+			t.Errorf("upstream closed %d times, expected exactly once", count)
+		} else if count == 0 {
+			t.Errorf("upstream was not closed, expected exactly once")
+		}
+	})
+	return e
+}
+
+func (e *CloseCountingEngine) Process(req *octollm.Request) (*octollm.Response, error) {
+	resp, err := e.inner.Process(req)
+	if err != nil {
+		return nil, err
+	}
+	closeFunc := func() {
+		atomic.AddInt32(e.closeCount, 1)
+	}
+	if resp.Stream != nil {
+		resp.Stream.OnClose(closeFunc)
+	} else if resp.Body != nil {
+		resp.Body.OnClose(closeFunc)
+	}
+	return resp, nil
 }
 
 // CollectSSEStream drains a stream response and returns its SSE wire bytes,


### PR DESCRIPTION
- converter/claude Process: close resp.Stream / resp.Body when the
  conversion step itself fails, so an early error doesn't leak the
  upstream stream or body.
- converter/claude convertStreamResponse: wrap req.Context with a
  cancellable ctx and expose cancel as the StreamChan closeFunc, so
  downstream Close() actually stops the conversion goroutine. sendEvent
  now selects on ctx.Done() to avoid pinning on a stuck send.
- rewrite: close resp.Body when reading the response bytes fails.