### PR TITLE
feat(types): add String() for non-stream response types

### DIFF
--- a/pkg/types/anthropic/stringer.go
+++ b/pkg/types/anthropic/stringer.go
@@ -117,3 +117,74 @@ func (r ClaudeMessagesRequest) String() string {
 	}
 	return fmt.Sprintf("(ClaudeMessagesRequest) {\n%s}", w.String())
 }
+
+// contentBlockString formats a MessageContentBlock safely for logging.
+func contentBlockString(b *MessageContentBlock) string {
+	if b == nil {
+		return "nil"
+	}
+	switch b.Type {
+	case "text":
+		if b.Text != nil {
+			return fmt.Sprintf("text(len=%d)", len(*b.Text))
+		}
+		return "text"
+	case "image":
+		return "image"
+	case "tool_use":
+		if b.MessageContentToolUse != nil {
+			return fmt.Sprintf("tool_use(name=%s,input_len=%d)", b.MessageContentToolUse.Name, len(b.MessageContentToolUse.Input))
+		}
+		return "tool_use"
+	case "tool_result":
+		if b.MessageContentToolResult != nil {
+			id := ""
+			if b.MessageContentToolResult.ToolUseID != nil {
+				id = *b.MessageContentToolResult.ToolUseID
+			}
+			return fmt.Sprintf("tool_result(id=%s,len=%d)", id, len(b.MessageContentToolResult.Content))
+		}
+		return "tool_result"
+	case "thinking":
+		if b.MessageContentThinking != nil {
+			return fmt.Sprintf("thinking(len=%d)", len(b.MessageContentThinking.Thinking))
+		}
+		return "thinking"
+	default:
+		return b.Type
+	}
+}
+
+// String formats ClaudeMessagesResponse safely for logging (no sensitive data).
+func (r ClaudeMessagesResponse) String() string {
+	w := &strings.Builder{}
+	fmt.Fprintf(w, "  ID: %q\n", r.ID)
+	if r.Type != "" {
+		fmt.Fprintf(w, "  Type: %q\n", r.Type)
+	}
+	if r.Role != "" {
+		fmt.Fprintf(w, "  Role: %q\n", r.Role)
+	}
+	fmt.Fprintf(w, "  Model: %q\n", r.Model)
+	fmt.Fprintf(w, "  Content: len(%d)\n", len(r.Content))
+	for _, b := range r.Content {
+		fmt.Fprintf(w, "    %s\n", contentBlockString(b))
+	}
+	if r.StopReason != "" {
+		fmt.Fprintf(w, "  StopReason: %s\n", r.StopReason)
+	}
+	if r.StopSequence != nil {
+		fmt.Fprintf(w, "  StopSequence: %q\n", *r.StopSequence)
+	}
+	if u := r.Usage; u != nil {
+		fmt.Fprintf(w, "  Usage: input=%d, output=%d", u.InputTokens, u.OutputTokens)
+		if u.CacheCreationInputTokens != nil {
+			fmt.Fprintf(w, ", cache_creation=%d", *u.CacheCreationInputTokens)
+		}
+		if u.CacheReadInputTokens != nil {
+			fmt.Fprintf(w, ", cache_read=%d", *u.CacheReadInputTokens)
+		}
+		w.WriteString("\n")
+	}
+	return fmt.Sprintf("(ClaudeMessagesResponse) {\n%s}", w.String())
+}

--- a/pkg/types/anthropic/stringer_test.go
+++ b/pkg/types/anthropic/stringer_test.go
@@ -143,3 +143,105 @@ func TestClaudeMessagesRequest_String(t *testing.T) {
 		})
 	}
 }
+
+func mustUnmarshalResp(t *testing.T, jsonStr string) ClaudeMessagesResponse {
+	t.Helper()
+	var resp ClaudeMessagesResponse
+	require.NoError(t, json.Unmarshal([]byte(jsonStr), &resp))
+	return resp
+}
+
+func TestClaudeMessagesResponse_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		json     string
+		expected string
+	}{
+		{
+			name: "text response with cache usage",
+			json: `{
+				"id": "msg_01ABC",
+				"type": "message",
+				"role": "assistant",
+				"model": "claude-3-5-sonnet-20241022",
+				"content": [{"type": "text", "text": "Hello, world!"}],
+				"stop_reason": "end_turn",
+				"usage": {"input_tokens": 10, "output_tokens": 5, "cache_read_input_tokens": 3}
+			}`,
+			// "Hello, world!" = 13 bytes
+			expected: `(ClaudeMessagesResponse) {
+  ID: "msg_01ABC"
+  Type: "message"
+  Role: "assistant"
+  Model: "claude-3-5-sonnet-20241022"
+  Content: len(1)
+    text(len=13)
+  StopReason: end_turn
+  Usage: input=10, output=5, cache_read=3
+}`,
+		},
+		{
+			name: "tool use response",
+			json: `{
+				"id": "msg_02",
+				"type": "message",
+				"role": "assistant",
+				"model": "claude-3-5-sonnet-20241022",
+				"content": [
+					{"type": "text", "text": "Let me check"},
+					{"type": "tool_use", "id": "tool_1", "name": "get_weather", "input": {"city":"NYC"}}
+				],
+				"stop_reason": "tool_use",
+				"usage": {"input_tokens": 20, "output_tokens": 15}
+			}`,
+			// "Let me check" = 12 bytes; input raw JSON `{"city":"NYC"}` = 14 bytes
+			expected: `(ClaudeMessagesResponse) {
+  ID: "msg_02"
+  Type: "message"
+  Role: "assistant"
+  Model: "claude-3-5-sonnet-20241022"
+  Content: len(2)
+    text(len=12)
+    tool_use(name=get_weather,input_len=14)
+  StopReason: tool_use
+  Usage: input=20, output=15
+}`,
+		},
+		{
+			name: "thinking content with stop_sequence and cache_creation",
+			json: `{
+				"id": "msg_03",
+				"type": "message",
+				"role": "assistant",
+				"model": "claude-3-5-sonnet-20241022",
+				"content": [
+					{"type": "thinking", "thinking": "thinking text"},
+					{"type": "text", "text": "answer"}
+				],
+				"stop_reason": "stop_sequence",
+				"stop_sequence": "END",
+				"usage": {"input_tokens": 7, "output_tokens": 4, "cache_creation_input_tokens": 2}
+			}`,
+			// "thinking text" = 13 bytes, "answer" = 6 bytes
+			expected: `(ClaudeMessagesResponse) {
+  ID: "msg_03"
+  Type: "message"
+  Role: "assistant"
+  Model: "claude-3-5-sonnet-20241022"
+  Content: len(2)
+    thinking(len=13)
+    text(len=6)
+  StopReason: stop_sequence
+  StopSequence: "END"
+  Usage: input=7, output=4, cache_creation=2
+}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := mustUnmarshalResp(t, tt.json)
+			assert.Equal(t, tt.expected, resp.String())
+		})
+	}
+}

--- a/pkg/types/openai/stringer.go
+++ b/pkg/types/openai/stringer.go
@@ -226,3 +226,157 @@ func (s StopUnion) String() string {
 	}
 	return fmt.Sprintf("%v", s.Array)
 }
+
+// usageString formats a Usage safely for logging.
+func usageString(u *Usage) string {
+	if u == nil {
+		return ""
+	}
+	w := &strings.Builder{}
+	fmt.Fprintf(w, "prompt=%d, completion=%d, total=%d", u.PromptTokens, u.CompletionTokens, u.TotalTokens)
+	if d := u.CompletionTokensDetails; d != nil {
+		if d.ReasoningTokens > 0 {
+			fmt.Fprintf(w, ", reasoning=%d", d.ReasoningTokens)
+		}
+		if d.AudioTokens > 0 {
+			fmt.Fprintf(w, ", completion_audio=%d", d.AudioTokens)
+		}
+	}
+	if d := u.PromptTokensDetails; d != nil {
+		if d.CachedTokens > 0 {
+			fmt.Fprintf(w, ", cached=%d", d.CachedTokens)
+		}
+		if d.AudioTokens > 0 {
+			fmt.Fprintf(w, ", prompt_audio=%d", d.AudioTokens)
+		}
+	}
+	return w.String()
+}
+
+// String formats ChatCompletionResponse safely for logging (no sensitive data).
+func (r ChatCompletionResponse) String() string {
+	w := &strings.Builder{}
+	fmt.Fprintf(w, "  ID: %q\n", r.ID)
+	fmt.Fprintf(w, "  Model: %q\n", r.Model)
+	if r.Object != "" {
+		fmt.Fprintf(w, "  Object: %q\n", r.Object)
+	}
+	fmt.Fprintf(w, "  Created: %d\n", r.Created)
+	fmt.Fprintf(w, "  Choices: len(%d)\n", len(r.Choices))
+	for _, c := range r.Choices {
+		if c == nil {
+			continue
+		}
+		fmt.Fprintf(w, "    Choice{index=%d, finish_reason=%s", c.Index, c.FinishReason)
+		if c.Message != nil {
+			fmt.Fprintf(w, ", message=%s", c.Message.String())
+		}
+		w.WriteString("}\n")
+	}
+	if u := usageString(r.Usage); u != "" {
+		fmt.Fprintf(w, "  Usage: %s\n", u)
+	}
+	if r.Blocked != nil {
+		fmt.Fprintf(w, "  Blocked: %t\n", *r.Blocked)
+	}
+	if r.SystemFingerprint != nil {
+		fmt.Fprintf(w, "  SystemFingerprint: %q\n", *r.SystemFingerprint)
+	}
+	if r.ServiceTier != nil {
+		fmt.Fprintf(w, "  ServiceTier: %q\n", *r.ServiceTier)
+	}
+	return fmt.Sprintf("(ChatCompletionResponse) {\n%s}", w.String())
+}
+
+// String formats CompletionResponse safely for logging (no sensitive data).
+func (r CompletionResponse) String() string {
+	w := &strings.Builder{}
+	fmt.Fprintf(w, "  ID: %q\n", r.ID)
+	fmt.Fprintf(w, "  Model: %q\n", r.Model)
+	if r.Object != "" {
+		fmt.Fprintf(w, "  Object: %q\n", r.Object)
+	}
+	fmt.Fprintf(w, "  Created: %d\n", r.Created)
+	fmt.Fprintf(w, "  Choices: len(%d)\n", len(r.Choices))
+	for _, c := range r.Choices {
+		finish := ""
+		if c.FinishReason != nil {
+			finish = *c.FinishReason
+		}
+		fmt.Fprintf(w, "    Choice{index=%d, text_len=%d, finish_reason=%s}\n", c.Index, len(c.Text), finish)
+	}
+	if u := usageString(r.Usage); u != "" {
+		fmt.Fprintf(w, "  Usage: %s\n", u)
+	}
+	if r.SystemFingerprint != nil {
+		fmt.Fprintf(w, "  SystemFingerprint: %q\n", *r.SystemFingerprint)
+	}
+	return fmt.Sprintf("(CompletionResponse) {\n%s}", w.String())
+}
+
+// String formats EmbeddingResponse safely for logging (no sensitive data).
+func (r EmbeddingResponse) String() string {
+	w := &strings.Builder{}
+	fmt.Fprintf(w, "  Model: %q\n", r.Model)
+	if r.Object != "" {
+		fmt.Fprintf(w, "  Object: %q\n", r.Object)
+	}
+	fmt.Fprintf(w, "  Data: len(%d)\n", len(r.Data))
+	for _, d := range r.Data {
+		fmt.Fprintf(w, "    Embedding{index=%d, dims=%d}\n", d.Index, len(d.Embedding))
+	}
+	fmt.Fprintf(w, "  Usage: prompt=%d, total=%d\n", r.Usage.PromptTokens, r.Usage.TotalTokens)
+	return fmt.Sprintf("(EmbeddingResponse) {\n%s}", w.String())
+}
+
+// responsesOutputItemString formats a ResponsesOutputItem safely for logging.
+func responsesOutputItemString(i *ResponsesOutputItem) string {
+	if i == nil {
+		return "nil"
+	}
+	w := &strings.Builder{}
+	fmt.Fprintf(w, "{id=%s, type=%s", i.ID, i.Type)
+	if i.Role != "" {
+		fmt.Fprintf(w, ", role=%s", i.Role)
+	}
+	if len(i.Content) > 0 {
+		fmt.Fprintf(w, ", content=[")
+		for _, p := range i.Content {
+			if p == nil {
+				continue
+			}
+			switch p.Type {
+			case "output_text":
+				fmt.Fprintf(w, "output_text(len=%d), ", len(p.Text))
+			case "refusal":
+				fmt.Fprintf(w, "refusal(len=%d), ", len(p.Refusal))
+			default:
+				fmt.Fprintf(w, "%s, ", p.Type)
+			}
+		}
+		w.WriteString("]")
+	}
+	w.WriteString("}")
+	return w.String()
+}
+
+// String formats ResponsesResponse safely for logging (no sensitive data).
+func (r ResponsesResponse) String() string {
+	w := &strings.Builder{}
+	fmt.Fprintf(w, "  ID: %q\n", r.Id)
+	fmt.Fprintf(w, "  Output: len(%d)\n", len(r.Output))
+	for _, item := range r.Output {
+		fmt.Fprintf(w, "    %s\n", responsesOutputItemString(item))
+	}
+	if u := r.Usage; u != nil {
+		fmt.Fprintf(w, "  Usage: input=%d, output=%d, total=%d", u.InputTokens, u.OutputTokens, u.TotalTokens)
+		if d := u.InputTokensDetails; d != nil && d.CachedTokens > 0 {
+			fmt.Fprintf(w, ", cached=%d", d.CachedTokens)
+		}
+		if d := u.OutputTokensDetails; d != nil && d.ReasoningTokens > 0 {
+			fmt.Fprintf(w, ", reasoning=%d", d.ReasoningTokens)
+		}
+		w.WriteString("\n")
+	}
+	return fmt.Sprintf("(ResponsesResponse) {\n%s}", w.String())
+}

--- a/pkg/types/openai/stringer_test.go
+++ b/pkg/types/openai/stringer_test.go
@@ -175,3 +175,257 @@ func TestCompletionRequest_String(t *testing.T) {
 		})
 	}
 }
+
+func mustUnmarshalChatResp(t *testing.T, jsonStr string) ChatCompletionResponse {
+	t.Helper()
+	var resp ChatCompletionResponse
+	require.NoError(t, json.Unmarshal([]byte(jsonStr), &resp))
+	return resp
+}
+
+func TestChatCompletionResponse_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		json     string
+		expected string
+	}{
+		{
+			name: "basic response with usage",
+			json: `{
+				"id": "chatcmpl-123",
+				"object": "chat.completion",
+				"created": 1700000000,
+				"model": "gpt-4",
+				"choices": [{
+					"index": 0,
+					"message": {"role": "assistant", "content": "Hello there!"},
+					"finish_reason": "stop"
+				}],
+				"usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
+			}`,
+			// "Hello there!" = 12 bytes
+			expected: `(ChatCompletionResponse) {
+  ID: "chatcmpl-123"
+  Model: "gpt-4"
+  Object: "chat.completion"
+  Created: 1700000000
+  Choices: len(1)
+    Choice{index=0, finish_reason=stop, message=(Message) {Role: "assistant", Content: len(12), }}
+  Usage: prompt=10, completion=5, total=15
+}`,
+		},
+		{
+			name: "with token details and fingerprint",
+			json: `{
+				"id": "chatcmpl-456",
+				"object": "chat.completion",
+				"created": 1700000001,
+				"model": "o1",
+				"choices": [{
+					"index": 0,
+					"message": {"role": "assistant", "content": "ok"},
+					"finish_reason": "stop"
+				}],
+				"usage": {
+					"prompt_tokens": 8,
+					"completion_tokens": 4,
+					"total_tokens": 12,
+					"completion_tokens_details": {"reasoning_tokens": 3},
+					"prompt_tokens_details": {"cached_tokens": 2}
+				},
+				"system_fingerprint": "fp_abc",
+				"service_tier": "default"
+			}`,
+			expected: `(ChatCompletionResponse) {
+  ID: "chatcmpl-456"
+  Model: "o1"
+  Object: "chat.completion"
+  Created: 1700000001
+  Choices: len(1)
+    Choice{index=0, finish_reason=stop, message=(Message) {Role: "assistant", Content: len(2), }}
+  Usage: prompt=8, completion=4, total=12, reasoning=3, cached=2
+  SystemFingerprint: "fp_abc"
+  ServiceTier: "default"
+}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := mustUnmarshalChatResp(t, tt.json)
+			assert.Equal(t, tt.expected, resp.String())
+		})
+	}
+}
+
+func mustUnmarshalCompletionResp(t *testing.T, jsonStr string) CompletionResponse {
+	t.Helper()
+	var resp CompletionResponse
+	require.NoError(t, json.Unmarshal([]byte(jsonStr), &resp))
+	return resp
+}
+
+func TestCompletionResponse_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		json     string
+		expected string
+	}{
+		{
+			name: "single choice",
+			json: `{
+				"id": "cmpl-1",
+				"object": "text_completion",
+				"created": 1700000000,
+				"model": "gpt-3.5-turbo-instruct",
+				"choices": [{"text": "Hello", "index": 0, "finish_reason": "stop"}],
+				"usage": {"prompt_tokens": 5, "completion_tokens": 1, "total_tokens": 6}
+			}`,
+			// "Hello" = 5 bytes
+			expected: `(CompletionResponse) {
+  ID: "cmpl-1"
+  Model: "gpt-3.5-turbo-instruct"
+  Object: "text_completion"
+  Created: 1700000000
+  Choices: len(1)
+    Choice{index=0, text_len=5, finish_reason=stop}
+  Usage: prompt=5, completion=1, total=6
+}`,
+		},
+		{
+			name: "no usage, with fingerprint",
+			json: `{
+				"id": "cmpl-2",
+				"object": "text_completion",
+				"created": 1700000001,
+				"model": "gpt-3.5-turbo-instruct",
+				"choices": [{"text": "abcd", "index": 0}],
+				"system_fingerprint": "fp_xyz"
+			}`,
+			expected: `(CompletionResponse) {
+  ID: "cmpl-2"
+  Model: "gpt-3.5-turbo-instruct"
+  Object: "text_completion"
+  Created: 1700000001
+  Choices: len(1)
+    Choice{index=0, text_len=4, finish_reason=}
+  SystemFingerprint: "fp_xyz"
+}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := mustUnmarshalCompletionResp(t, tt.json)
+			assert.Equal(t, tt.expected, resp.String())
+		})
+	}
+}
+
+func mustUnmarshalEmbeddingResp(t *testing.T, jsonStr string) EmbeddingResponse {
+	t.Helper()
+	var resp EmbeddingResponse
+	require.NoError(t, json.Unmarshal([]byte(jsonStr), &resp))
+	return resp
+}
+
+func TestEmbeddingResponse_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		json     string
+		expected string
+	}{
+		{
+			name: "two embeddings",
+			json: `{
+				"object": "list",
+				"data": [
+					{"object": "embedding", "index": 0, "embedding": [0.1, 0.2, 0.3]},
+					{"object": "embedding", "index": 1, "embedding": [0.4, 0.5, 0.6, 0.7]}
+				],
+				"model": "text-embedding-3-small",
+				"usage": {"prompt_tokens": 8, "total_tokens": 8}
+			}`,
+			expected: `(EmbeddingResponse) {
+  Model: "text-embedding-3-small"
+  Object: "list"
+  Data: len(2)
+    Embedding{index=0, dims=3}
+    Embedding{index=1, dims=4}
+  Usage: prompt=8, total=8
+}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := mustUnmarshalEmbeddingResp(t, tt.json)
+			assert.Equal(t, tt.expected, resp.String())
+		})
+	}
+}
+
+func mustUnmarshalResponsesResp(t *testing.T, jsonStr string) ResponsesResponse {
+	t.Helper()
+	var resp ResponsesResponse
+	require.NoError(t, json.Unmarshal([]byte(jsonStr), &resp))
+	return resp
+}
+
+func TestResponsesResponse_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		json     string
+		expected string
+	}{
+		{
+			name: "output_text and refusal with detailed usage",
+			json: `{
+				"id": "resp_1",
+				"output": [{
+					"id": "msg_1",
+					"type": "message",
+					"role": "assistant",
+					"content": [
+						{"type": "output_text", "text": "Hello"},
+						{"type": "refusal", "refusal": "Cannot"}
+					]
+				}],
+				"usage": {
+					"input_tokens": 10,
+					"output_tokens": 5,
+					"total_tokens": 15,
+					"input_tokens_details": {"cached_tokens": 2},
+					"output_tokens_details": {"reasoning_tokens": 3}
+				}
+			}`,
+			// "Hello" = 5, "Cannot" = 6
+			expected: `(ResponsesResponse) {
+  ID: "resp_1"
+  Output: len(1)
+    {id=msg_1, type=message, role=assistant, content=[output_text(len=5), refusal(len=6), ]}
+  Usage: input=10, output=5, total=15, cached=2, reasoning=3
+}`,
+		},
+		{
+			name: "minimal usage",
+			json: `{
+				"id": "resp_2",
+				"output": [],
+				"usage": {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3}
+			}`,
+			expected: `(ResponsesResponse) {
+  ID: "resp_2"
+  Output: len(0)
+  Usage: input=1, output=2, total=3
+}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := mustUnmarshalResponsesResp(t, tt.json)
+			assert.Equal(t, tt.expected, resp.String())
+		})
+	}
+}

--- a/pkg/types/rerank/stringer.go
+++ b/pkg/types/rerank/stringer.go
@@ -22,3 +22,15 @@ func (r RerankRequest) String() string {
 	}
 	return fmt.Sprintf("(RerankRequest) {\n%s}", w.String())
 }
+
+// String formats RerankResponse safely for logging (no sensitive data).
+func (r RerankResponse) String() string {
+	w := &strings.Builder{}
+	fmt.Fprintf(w, "  Model: %q\n", r.Model)
+	fmt.Fprintf(w, "  Results: len(%d)\n", len(r.Results))
+	for _, res := range r.Results {
+		fmt.Fprintf(w, "    Result{index=%d, relevance_score=%.6f, document_len=%d}\n", res.Index, res.RelevanceScore, len(res.Document.Text))
+	}
+	fmt.Fprintf(w, "  Usage: prompt=%d, total=%d\n", r.Usage.PromptTokens, r.Usage.TotalTokens)
+	return fmt.Sprintf("(RerankResponse) {\n%s}", w.String())
+}

--- a/pkg/types/rerank/stringer_test.go
+++ b/pkg/types/rerank/stringer_test.go
@@ -1,0 +1,92 @@
+package rerank
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func mustUnmarshalRerankReq(t *testing.T, jsonStr string) RerankRequest {
+	t.Helper()
+	var req RerankRequest
+	require.NoError(t, json.Unmarshal([]byte(jsonStr), &req))
+	return req
+}
+
+func TestRerankRequest_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		json     string
+		expected string
+	}{
+		{
+			name: "basic with top_n and return_documents",
+			json: `{
+				"query": "What is the capital of France?",
+				"model": "bge-reranker-v2-m3",
+				"documents": ["Paris is the capital of France.", "London is the capital of England."],
+				"return_documents": true,
+				"top_n": 5
+			}`,
+			// "What is the capital of France?" = 30 bytes
+			expected: `(RerankRequest) {
+  Model: "bge-reranker-v2-m3"
+  Query: len(30)
+  Documents: len(2)
+  TopN: 5
+  ReturnDocuments: true
+}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := mustUnmarshalRerankReq(t, tt.json)
+			assert.Equal(t, tt.expected, req.String())
+		})
+	}
+}
+
+func mustUnmarshalRerankResp(t *testing.T, jsonStr string) RerankResponse {
+	t.Helper()
+	var resp RerankResponse
+	require.NoError(t, json.Unmarshal([]byte(jsonStr), &resp))
+	return resp
+}
+
+func TestRerankResponse_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		json     string
+		expected string
+	}{
+		{
+			name: "two results",
+			json: `{
+				"results": [
+					{"index": 0, "relevance_score": 0.95, "document": {"text": "Paris is..."}},
+					{"index": 1, "relevance_score": 0.5, "document": {"text": "London"}}
+				],
+				"model": "bge-reranker-v2-m3",
+				"usage": {"prompt_tokens": 10, "total_tokens": 10}
+			}`,
+			// "Paris is..." = 11, "London" = 6
+			expected: `(RerankResponse) {
+  Model: "bge-reranker-v2-m3"
+  Results: len(2)
+    Result{index=0, relevance_score=0.950000, document_len=11}
+    Result{index=1, relevance_score=0.500000, document_len=6}
+  Usage: prompt=10, total=10
+}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := mustUnmarshalRerankResp(t, tt.json)
+			assert.Equal(t, tt.expected, resp.String())
+		})
+	}
+}


### PR DESCRIPTION
Mirrors the request stringers: length-only fields, no sensitive content. Covers ClaudeMessagesResponse, ChatCompletionResponse, CompletionResponse, EmbeddingResponse, ResponsesResponse, and RerankResponse.