### PR TITLE
limiter: color marker/limiter priority on request metadata

### DIFF
--- a/pkg/engines/limiter/color_metadata.go
+++ b/pkg/engines/limiter/color_metadata.go
@@ -1,0 +1,104 @@
+package limiter
+
+import (
+	"github.com/infinigence/octollm/pkg/octollm"
+)
+
+// Color actions stored on request metadata.
+const (
+	// ColorActionAllow is 通过 (request allowed at the recorded priority).
+	ColorActionAllow = "allow"
+	// ColorActionDeny is 拦截 (rate-limited at the recorded priority).
+	ColorActionDeny = "deny"
+)
+
+type markerPriorityMetadataKey struct{}
+type markerActionMetadataKey struct{}
+type limiterPriorityMetadataKey struct{}
+type limiterActionMetadataKey struct{}
+
+// GetMarkerPriority returns the marker-assigned priority band (0 = lowest).
+// The second value is false when unset (nil request, never passed a marker, or non–rate-limit error).
+func GetMarkerPriority(req *octollm.Request) (int, bool) {
+	return getColorPriority(req, markerPriorityMetadataKey{})
+}
+
+// GetMarkerAction returns ColorActionAllow or ColorActionDeny.
+// The second value is false when unset.
+func GetMarkerAction(req *octollm.Request) (string, bool) {
+	return getColorAction(req, markerActionMetadataKey{})
+}
+
+// GetLimiterPriority returns the limiter-evaluated priority band (from context / marker).
+// The second value is false when unset.
+func GetLimiterPriority(req *octollm.Request) (int, bool) {
+	return getColorPriority(req, limiterPriorityMetadataKey{})
+}
+
+// GetLimiterAction returns ColorActionAllow or ColorActionDeny.
+// The second value is false when unset.
+func GetLimiterAction(req *octollm.Request) (string, bool) {
+	return getColorAction(req, limiterActionMetadataKey{})
+}
+
+func getColorPriority(req *octollm.Request, key any) (int, bool) {
+	if req == nil {
+		return 0, false
+	}
+	raw, ok := req.GetMetadataValue(key)
+	if !ok {
+		return 0, false
+	}
+	p, ok := raw.(int)
+	if !ok {
+		return 0, false
+	}
+	return p, true
+}
+
+func getColorAction(req *octollm.Request, key any) (string, bool) {
+	if req == nil {
+		return "", false
+	}
+	raw, ok := req.GetMetadataValue(key)
+	if !ok {
+		return "", false
+	}
+	s, ok := raw.(string)
+	if !ok || s == "" {
+		return "", false
+	}
+	return s, true
+}
+
+func setMarkerColor(req *octollm.Request, priority int, action string) {
+	if req == nil {
+		return
+	}
+	req.SetMetadataValue(markerPriorityMetadataKey{}, priority)
+	req.SetMetadataValue(markerActionMetadataKey{}, action)
+}
+
+func setLimiterColor(req *octollm.Request, priority int, action string) {
+	if req == nil {
+		return
+	}
+	req.SetMetadataValue(limiterPriorityMetadataKey{}, priority)
+	req.SetMetadataValue(limiterActionMetadataKey{}, action)
+}
+
+func recordMarkerAllow(req *octollm.Request, priority int) {
+	setMarkerColor(req, priority, ColorActionAllow)
+}
+
+func recordMarkerDeny(req *octollm.Request, priority int) {
+	setMarkerColor(req, priority, ColorActionDeny)
+}
+
+func recordLimiterAllow(req *octollm.Request, priority int) {
+	setLimiterColor(req, priority, ColorActionAllow)
+}
+
+func recordLimiterDeny(req *octollm.Request, priority int) {
+	setLimiterColor(req, priority, ColorActionDeny)
+}

--- a/pkg/engines/limiter/color_metadata_test.go
+++ b/pkg/engines/limiter/color_metadata_test.go
@@ -1,0 +1,48 @@
+package limiter
+
+import (
+	"testing"
+
+	"github.com/infinigence/octollm/pkg/octollm"
+	"github.com/stretchr/testify/assert"
+)
+
+func assertMarkerAllow(t *testing.T, req *octollm.Request, wantPriority int) {
+	t.Helper()
+	p, ok := GetMarkerPriority(req)
+	assert.True(t, ok)
+	assert.Equal(t, wantPriority, p)
+	a, ok := GetMarkerAction(req)
+	assert.True(t, ok)
+	assert.Equal(t, ColorActionAllow, a)
+}
+
+func assertMarkerDeny(t *testing.T, req *octollm.Request, wantPriority int) {
+	t.Helper()
+	p, ok := GetMarkerPriority(req)
+	assert.True(t, ok)
+	assert.Equal(t, wantPriority, p)
+	a, ok := GetMarkerAction(req)
+	assert.True(t, ok)
+	assert.Equal(t, ColorActionDeny, a)
+}
+
+func assertLimiterAllow(t *testing.T, req *octollm.Request, wantPriority int) {
+	t.Helper()
+	p, ok := GetLimiterPriority(req)
+	assert.True(t, ok)
+	assert.Equal(t, wantPriority, p)
+	a, ok := GetLimiterAction(req)
+	assert.True(t, ok)
+	assert.Equal(t, ColorActionAllow, a)
+}
+
+func assertLimiterDeny(t *testing.T, req *octollm.Request, wantPriority int) {
+	t.Helper()
+	p, ok := GetLimiterPriority(req)
+	assert.True(t, ok)
+	assert.Equal(t, wantPriority, p)
+	a, ok := GetLimiterAction(req)
+	assert.True(t, ok)
+	assert.Equal(t, ColorActionDeny, a)
+}

--- a/pkg/engines/limiter/concurrency_color_limiter.go
+++ b/pkg/engines/limiter/concurrency_color_limiter.go
@@ -2,6 +2,7 @@ package limiter
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"runtime/debug"
@@ -88,14 +89,15 @@ func NewConcurrencyColorLimiterEngine(redisClient *redis.Client, key string, tot
 	}, nil
 }
 
-// allow attempts to allow the request to pass through, performing rate limiting check
-func (e *ConcurrencyColorLimiterEngine) allow(ctx context.Context) (done func(), err error) {
+// allow attempts to allow the request to pass through, performing rate limiting check.
+// When the limiter is disabled (pass-through), returns priority 0 (recorded as allow at priority 0).
+func (e *ConcurrencyColorLimiterEngine) allow(ctx context.Context) (done func(), priority int, err error) {
 	// If concurrencyRates is empty, directly pass through
 	if len(e.concurrencyRates) == 0 || e.acquireSingleScript == nil {
-		return func() {}, nil
+		return func() {}, 0, nil
 	}
 
-	priority := 0
+	priority = 0
 	if p, ok := e.getPriorityFromContext(ctx); ok {
 		priority = p
 	}
@@ -131,13 +133,13 @@ func (e *ConcurrencyColorLimiterEngine) allow(ctx context.Context) (done func(),
 			tier0Limit, nowUnix, expireBefore, memberID).Result()
 		if err != nil {
 			slog.ErrorContext(ctx, fmt.Sprintf("acquire script error for tier 0: %v, key: %s", err, tier0Key))
-			return func() {}, fmt.Errorf("acquire script error: %w", err)
+			return func() {}, 0, fmt.Errorf("acquire script error: %w", err)
 		}
 
 		results, ok := result.([]interface{})
 		if !ok || len(results) != 2 {
 			slog.ErrorContext(ctx, fmt.Sprintf("unexpected script result format for tier 0, key: %s", tier0Key))
-			return func() {}, fmt.Errorf("unexpected script result format")
+			return func() {}, 0, fmt.Errorf("unexpected script result format")
 		}
 
 		acquiredInt, _ := results[0].(int64)
@@ -145,7 +147,7 @@ func (e *ConcurrencyColorLimiterEngine) allow(ctx context.Context) (done func(),
 
 		if acquiredInt == 0 {
 			slog.WarnContext(ctx, fmt.Sprintf("tier 0 concurrency limit %d reached, current: %d, key: %s", tier0Limit, tier0Count, tier0Key))
-			return func() {}, ErrRateLimitReached
+			return func() {}, priority, ErrRateLimitReached
 		}
 
 		// Start renewal goroutine
@@ -164,7 +166,7 @@ func (e *ConcurrencyColorLimiterEngine) allow(ctx context.Context) (done func(),
 		}
 
 		slog.InfoContext(ctx, fmt.Sprintf("max priority concurrency allowed, tier 0 count: %d/%d, key: %s", tier0Count, tier0Limit, tier0Key))
-		return done, nil
+		return done, priority, nil
 	} else {
 		// Non-max priority: atomically check own tier and tier 0 with reservation
 		ownKey := fmt.Sprintf("%s:tier_%d", e.key, tierIdx)
@@ -180,13 +182,13 @@ func (e *ConcurrencyColorLimiterEngine) allow(ctx context.Context) (done func(),
 			ownLimit, tier0Limit, nowUnix, expireBefore, memberID, reservedSlots).Result()
 		if err != nil {
 			slog.ErrorContext(ctx, fmt.Sprintf("dual acquire script error: %v, ownKey: %s, tier0Key: %s", err, ownKey, tier0Key))
-			return func() {}, fmt.Errorf("acquire script error: %w", err)
+			return func() {}, 0, fmt.Errorf("acquire script error: %w", err)
 		}
 
 		results, ok := result.([]interface{})
 		if !ok || len(results) != 3 {
 			slog.ErrorContext(ctx, fmt.Sprintf("unexpected script result format, ownKey: %s, tier0Key: %s", ownKey, tier0Key))
-			return func() {}, fmt.Errorf("unexpected script result format")
+			return func() {}, 0, fmt.Errorf("unexpected script result format")
 		}
 
 		acquiredInt, _ := results[0].(int64)
@@ -196,7 +198,7 @@ func (e *ConcurrencyColorLimiterEngine) allow(ctx context.Context) (done func(),
 		if acquiredInt == 0 {
 			slog.WarnContext(ctx, fmt.Sprintf("concurrency limit reached for priority %d (tier %d), ownCount: %d/%d, tier0Count: %d/%d (reserved: %d)",
 				priority, tierIdx, ownCount, ownLimit, tier0Count, tier0Limit, reservedSlots))
-			return func() {}, ErrRateLimitReached
+			return func() {}, priority, ErrRateLimitReached
 		}
 
 		// Start renewal goroutine
@@ -216,19 +218,22 @@ func (e *ConcurrencyColorLimiterEngine) allow(ctx context.Context) (done func(),
 
 		slog.InfoContext(ctx, fmt.Sprintf("concurrency allowed for priority %d (tier %d), ownCount: %d/%d, tier0Count: %d/%d (reserved: %d)",
 			priority, tierIdx, ownCount, ownLimit, tier0Count, tier0Limit, reservedSlots))
-		return done, nil
+		return done, priority, nil
 	}
 }
 
 func (e *ConcurrencyColorLimiterEngine) Process(req *octollm.Request) (*octollm.Response, error) {
 	ctx := req.Context()
 
-	// Use allow method to perform rate limiting
-	done, err := e.allow(ctx)
+	done, priority, err := e.allow(ctx)
 	if err != nil {
 		slog.ErrorContext(ctx, fmt.Sprintf("concurrency rate limiter error: %v, key: %s", err, e.key))
+		if errors.Is(err, ErrRateLimitReached) {
+			recordLimiterDeny(req, priority)
+		}
 		return nil, err
 	}
+	recordLimiterAllow(req, priority)
 
 	// Process request
 	resp, err := e.next.Process(req)

--- a/pkg/engines/limiter/concurrency_color_limiter_test.go
+++ b/pkg/engines/limiter/concurrency_color_limiter_test.go
@@ -151,6 +151,7 @@ func TestConcurrencyColorLimiter_PassThroughWhenDisabled(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, 1, next.callCount)
+	assertLimiterAllow(t, req, 0)
 }
 
 func TestConcurrencyColorLimiter_PriorityMappingAndReservation(t *testing.T) {
@@ -168,21 +169,27 @@ func TestConcurrencyColorLimiter_PriorityMappingAndReservation(t *testing.T) {
 
 	// Hold one max-priority slot (tier0Count becomes 1)
 	p1 := 1
-	resp1, err := e.Process(newConcurrencyColorLimiterTestRequest(t, ns, &p1))
+	req1 := newConcurrencyColorLimiterTestRequest(t, ns, &p1)
+	resp1, err := e.Process(req1)
 	assert.NoError(t, err)
 	assert.NotNil(t, resp1)
+	assertLimiterAllow(t, req1, 1)
 
 	// Now priority 0 should be denied because it requires tier0Count < (2-1)=1, but tier0Count is 1
 	p0 := 0
-	_, err = e.Process(newConcurrencyColorLimiterTestRequest(t, ns, &p0))
+	reqDenied := newConcurrencyColorLimiterTestRequest(t, ns, &p0)
+	_, err = e.Process(reqDenied)
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, ErrRateLimitReached)
+	assertLimiterDeny(t, reqDenied, 0)
 
 	// Release and try again: should allow
 	assert.NoError(t, resp1.Body.Close())
-	resp2, err := e.Process(newConcurrencyColorLimiterTestRequest(t, ns, &p0))
+	req2 := newConcurrencyColorLimiterTestRequest(t, ns, &p0)
+	resp2, err := e.Process(req2)
 	assert.NoError(t, err)
 	assert.NotNil(t, resp2)
+	assertLimiterAllow(t, req2, 0)
 	assert.NoError(t, resp2.Body.Close())
 }
 

--- a/pkg/engines/limiter/concurrency_color_marker.go
+++ b/pkg/engines/limiter/concurrency_color_marker.go
@@ -2,6 +2,7 @@ package limiter
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"runtime/debug"
@@ -109,11 +110,11 @@ func NewConcurrencyColorMarkerEngine(redisClient *redis.Client, key string, rate
 	}, nil
 }
 
-// allow attempts to allow the request to pass through, performing coloring and counting
-func (e *ConcurrencyColorMarkerEngine) allow(ctx context.Context) (newCtx context.Context, done func(), err error) {
+// Pass-through (no rates / no script) returns ctx unchanged, nil err, priority 0 (Process stores p0).
+func (e *ConcurrencyColorMarkerEngine) allow(ctx context.Context) (newCtx context.Context, done func(), err error, priority int) {
 	// If rates is empty, directly pass through
 	if len(e.rates) == 0 || e.acquireScript == nil {
-		return ctx, func() {}, nil
+		return ctx, func() {}, nil, 0
 	}
 
 	nowUnix := time.Now().Unix()
@@ -139,13 +140,13 @@ func (e *ConcurrencyColorMarkerEngine) allow(ctx context.Context) (newCtx contex
 	result, err := e.acquireScript.Run(ctx, e.redisClient, keys, args...).Result()
 	if err != nil {
 		slog.ErrorContext(ctx, fmt.Sprintf("acquire script error: %v, key: %s", err, e.key))
-		return ctx, func() {}, fmt.Errorf("acquire script error: %w", err)
+		return ctx, func() {}, fmt.Errorf("acquire script error: %w", err), 0
 	}
 
 	results, ok := result.([]any)
 	if !ok || len(results) < 2 {
 		slog.ErrorContext(ctx, fmt.Sprintf("unexpected script result format, key: %s", e.key))
-		return ctx, func() {}, fmt.Errorf("unexpected script result format")
+		return ctx, func() {}, fmt.Errorf("unexpected script result format"), 0
 	}
 
 	acquired, _ := results[0].(int64)
@@ -159,11 +160,11 @@ func (e *ConcurrencyColorMarkerEngine) allow(ctx context.Context) (newCtx contex
 	if acquired == 0 {
 		// All tiers exhausted
 		slog.WarnContext(ctx, fmt.Sprintf("all tiers exhausted, key: %s, usage: %s", e.key, formatTierUsage(counts, e.rates)))
-		return ctx, func() {}, ErrRateLimitReached
+		return ctx, func() {}, ErrRateLimitReached, 0
 	}
 
 	// acquired > 0: priority (1-based in Lua, convert to 0-based)
-	priority := int(acquired) - 1
+	priority = int(acquired) - 1
 	acquiredTierIdx := numTiers - 1 - priority
 	acquiredKeys := []string{keys[acquiredTierIdx]}
 
@@ -186,21 +187,22 @@ func (e *ConcurrencyColorMarkerEngine) allow(ctx context.Context) (newCtx contex
 	}
 
 	slog.InfoContext(ctx, fmt.Sprintf("acquired priority %d from tier %d, acquiredKeys: %v, usage: %s", priority, acquiredTierIdx, acquiredKeys, formatTierUsage(counts, e.rates)))
-	return newCtx, done, nil
+	return newCtx, done, nil, priority
 }
 
 func (e *ConcurrencyColorMarkerEngine) Process(req *octollm.Request) (*octollm.Response, error) {
 	ctx := req.Context()
 
-	// Use allow method to perform coloring
-	newCtx, done, err := e.allow(ctx)
+	newCtx, done, err, priority := e.allow(ctx)
 	if err != nil {
 		slog.ErrorContext(ctx, fmt.Sprintf("concurrency marker error: %v, key: %s", err, e.key))
+		if errors.Is(err, ErrRateLimitReached) {
+			recordMarkerDeny(req, priority)
+		}
 		return nil, err
 	}
-
-	// Use WithContext method to set new context
 	req = req.WithContext(newCtx)
+	recordMarkerAllow(req, priority)
 
 	// Process request
 	resp, err := e.next.Process(req)

--- a/pkg/engines/limiter/concurrency_color_marker_test.go
+++ b/pkg/engines/limiter/concurrency_color_marker_test.go
@@ -163,6 +163,7 @@ func TestConcurrencyColorMarker_PassThroughWhenDisabled(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, 1, next.callCount)
+	assertMarkerAllow(t, req, 0)
 }
 
 func TestConcurrencyColorMarker_PriorityAssignmentAndExhaustion(t *testing.T) {
@@ -178,20 +179,26 @@ func TestConcurrencyColorMarker_PriorityAssignmentAndExhaustion(t *testing.T) {
 	e, err := NewConcurrencyColorMarkerEngine(client, "marker-key", []int{1, 1}, 10*time.Second, ns, next)
 	assert.NoError(t, err)
 
-	resp1, err := e.Process(newConcurrencyColorMarkerTestRequest(t))
+	req1 := newConcurrencyColorMarkerTestRequest(t)
+	resp1, err := e.Process(req1)
 	assert.NoError(t, err)
 	assert.NotNil(t, resp1)
 	assert.Equal(t, 1, next.lastPriority)
+	assertMarkerAllow(t, req1, 1)
 
 	// Keep slot held (do not close resp1 yet)
-	resp2, err := e.Process(newConcurrencyColorMarkerTestRequest(t))
+	req2 := newConcurrencyColorMarkerTestRequest(t)
+	resp2, err := e.Process(req2)
 	assert.NoError(t, err)
 	assert.NotNil(t, resp2)
 	assert.Equal(t, 0, next.lastPriority)
+	assertMarkerAllow(t, req2, 0)
 
-	_, err = e.Process(newConcurrencyColorMarkerTestRequest(t))
+	req3 := newConcurrencyColorMarkerTestRequest(t)
+	_, err = e.Process(req3)
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, ErrRateLimitReached)
+	assertMarkerDeny(t, req3, 0)
 
 	// cleanup: close bodies to trigger release and stop renew goroutines
 	assert.NoError(t, resp1.Body.Close())
@@ -213,16 +220,20 @@ func TestConcurrencyColorMarker_EqualTierLimits_AllPriority1(t *testing.T) {
 
 	var resps []*octollm.Response
 	for i := 0; i < 3; i++ {
-		resp, err := e.Process(newConcurrencyColorMarkerTestRequest(t))
+		req := newConcurrencyColorMarkerTestRequest(t)
+		resp, err := e.Process(req)
 		assert.NoError(t, err)
 		assert.NotNil(t, resp)
 		assert.Equal(t, 1, next.lastPriority, "request %d should be colored priority 1", i+1)
+		assertMarkerAllow(t, req, 1)
 		resps = append(resps, resp)
 	}
 
-	_, err = e.Process(newConcurrencyColorMarkerTestRequest(t))
+	reqDenied := newConcurrencyColorMarkerTestRequest(t)
+	_, err = e.Process(reqDenied)
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, ErrRateLimitReached)
+	assertMarkerDeny(t, reqDenied, 0)
 	assert.Equal(t, 3, next.callCount, "denied request must not reach next")
 
 	for _, r := range resps {

--- a/pkg/engines/limiter/request_color_limiter.go
+++ b/pkg/engines/limiter/request_color_limiter.go
@@ -101,15 +101,16 @@ func NewRequestColorLimiterEngine(redisClient *redis.Client, keyPrefix string, t
 	}, nil
 }
 
-// allow attempts to consume tokens from token buckets based on request priority
-func (e *RequestColorLimiterEngine) allow(ctx context.Context) (done func(), err error) {
+// allow attempts to consume tokens from token buckets based on request priority.
+// When the limiter is disabled, returns priority 0 (recorded as allow at priority 0).
+func (e *RequestColorLimiterEngine) allow(ctx context.Context) (done func(), priority int, err error) {
 	// If configuration is invalid, directly pass through
 	if len(e.limits) == 0 || e.redisClient == nil || e.tokenBucketScript == nil {
-		return func() {}, nil
+		return func() {}, 0, nil
 	}
 
-	// Get priority from context (set by RequestColorMarkerEngine)
-	priority := 0
+	// Priority from context (set by RequestColorMarkerEngine); default 0 when absent.
+	priority = 0
 	if p, ok := e.getPriorityFromContext(ctx); ok {
 		priority = p
 	}
@@ -145,13 +146,13 @@ func (e *RequestColorLimiterEngine) allow(ctx context.Context) (done func(), err
 			burst, rate, nowUnix, e.ttls[0]).Result()
 		if err != nil {
 			slog.ErrorContext(ctx, fmt.Sprintf("[RequestColorLimiterEngine] token bucket script error for tier 0: %v, key: %s", err, key))
-			return func() {}, fmt.Errorf("token bucket script error: %w", err)
+			return func() {}, 0, fmt.Errorf("token bucket script error: %w", err)
 		}
 
 		results, ok := result.([]interface{})
 		if !ok || len(results) != 2 {
 			slog.ErrorContext(ctx, fmt.Sprintf("[RequestColorLimiterEngine] unexpected script result format for tier 0, key: %s", key))
-			return func() {}, fmt.Errorf("unexpected script result format")
+			return func() {}, 0, fmt.Errorf("unexpected script result format")
 		}
 
 		allowed, _ := results[0].(int64)
@@ -161,7 +162,7 @@ func (e *RequestColorLimiterEngine) allow(ctx context.Context) (done func(), err
 			slog.InfoContext(ctx, fmt.Sprintf("[RequestColorLimiterEngine] max priority request allowed, consumed from tier 0, tokens: %d/%d", tokens, burst))
 		} else {
 			slog.WarnContext(ctx, fmt.Sprintf("[RequestColorLimiterEngine] tier 0 rejected, tokens: %d/%d, key: %s", tokens, burst, key))
-			return func() {}, ErrRateLimitReached
+			return func() {}, priority, ErrRateLimitReached
 		}
 	} else {
 		// Non-max priority: atomically consume from both own tier and tier 0 with reservation
@@ -181,13 +182,13 @@ func (e *RequestColorLimiterEngine) allow(ctx context.Context) (done func(), err
 			ownBurst, ownRate, tier0Burst, tier0Rate, nowUnix, e.ttls[tierIdx], e.ttls[0], reservedTokens).Result()
 		if err != nil {
 			slog.ErrorContext(ctx, fmt.Sprintf("[RequestColorLimiterEngine] dual token bucket script error: %v, ownKey: %s, tier0Key: %s", err, ownKey, tier0Key))
-			return func() {}, fmt.Errorf("token bucket script error: %w", err)
+			return func() {}, 0, fmt.Errorf("token bucket script error: %w", err)
 		}
 
 		results, ok := result.([]interface{})
 		if !ok || len(results) != 3 {
 			slog.ErrorContext(ctx, fmt.Sprintf("[RequestColorLimiterEngine] unexpected script result format, ownKey: %s, tier0Key: %s", ownKey, tier0Key))
-			return func() {}, fmt.Errorf("unexpected script result format")
+			return func() {}, 0, fmt.Errorf("unexpected script result format")
 		}
 
 		allowed, _ := results[0].(int64)
@@ -200,24 +201,27 @@ func (e *RequestColorLimiterEngine) allow(ctx context.Context) (done func(), err
 		} else {
 			slog.WarnContext(ctx, fmt.Sprintf("[RequestColorLimiterEngine] request rejected with priority %d (tier %d), ownTokens: %d/%d, tier0Tokens: %d/%d (reserved: %d)",
 				priority, tierIdx, ownTokens, ownBurst, tier0Tokens, tier0Burst, reservedTokens))
-			return func() {}, ErrRateLimitReached
+			return func() {}, priority, ErrRateLimitReached
 		}
 	}
 
 	// done function doesn't need to do anything, as tokens are already consumed
 	done = func() {}
-	return done, nil
+	return done, priority, nil
 }
 
 func (e *RequestColorLimiterEngine) Process(req *octollm.Request) (*octollm.Response, error) {
 	ctx := req.Context()
 
-	// Use allow method to perform rate limiting
-	done, err := e.allow(ctx)
+	done, priority, err := e.allow(ctx)
 	if err != nil {
 		slog.ErrorContext(ctx, fmt.Sprintf("[RequestColorLimiterEngine] request rate limiter error: %v, keyPrefix: %s", err, e.keyPrefix))
+		if errors.Is(err, ErrRateLimitReached) {
+			recordLimiterDeny(req, priority)
+		}
 		return nil, err
 	}
+	recordLimiterAllow(req, priority)
 
 	// Process request
 	resp, err := e.next.Process(req)

--- a/pkg/engines/limiter/request_color_limiter_test.go
+++ b/pkg/engines/limiter/request_color_limiter_test.go
@@ -64,6 +64,7 @@ func TestRequestColorLimiter_PassThroughWhenDisabled(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, 1, next.callCount)
+	assertLimiterAllow(t, req, 0)
 }
 
 func TestRequestColorLimiter_PriorityInContext(t *testing.T) {
@@ -86,6 +87,7 @@ func TestRequestColorLimiter_PriorityInContext(t *testing.T) {
 		resp, err := e.Process(req)
 		assert.NoError(t, err)
 		assert.NotNil(t, resp)
+		assertLimiterAllow(t, req, 2)
 	}
 	assert.Equal(t, 5, next.callCount)
 
@@ -94,6 +96,7 @@ func TestRequestColorLimiter_PriorityInContext(t *testing.T) {
 	_, err = e.Process(req)
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, ErrRateLimitReached)
+	assertLimiterDeny(t, req, 2)
 	assert.Equal(t, 5, next.callCount)
 
 	// Priority 1: use fresh engine/keyPrefix so tier 0 has tokens
@@ -103,12 +106,14 @@ func TestRequestColorLimiter_PriorityInContext(t *testing.T) {
 		resp, err := e1.Process(req)
 		assert.NoError(t, err)
 		assert.NotNil(t, resp)
+		assertLimiterAllow(t, req, 1)
 	}
 	assert.Equal(t, 8, next.callCount)
 
 	req = newRequestColorLimiterTestRequest(t, ns, 1)
 	_, err = e1.Process(req)
 	assert.Error(t, err)
+	assertLimiterDeny(t, req, 1)
 	assert.Equal(t, 8, next.callCount)
 
 	// Priority 0: use fresh engine/keyPrefix
@@ -118,13 +123,51 @@ func TestRequestColorLimiter_PriorityInContext(t *testing.T) {
 		resp, err := e0.Process(req)
 		assert.NoError(t, err)
 		assert.NotNil(t, resp)
+		assertLimiterAllow(t, req, 0)
 	}
 	assert.Equal(t, 10, next.callCount)
 
 	req = newRequestColorLimiterTestRequest(t, ns, 0)
 	_, err = e0.Process(req)
 	assert.Error(t, err)
+	assertLimiterDeny(t, req, 0)
 	assert.Equal(t, 10, next.callCount)
+}
+
+func TestRequestColorLimiter_DeniedColorMetadata(t *testing.T) {
+	t.Parallel()
+	mr := miniredis.RunT(t)
+	defer mr.Close()
+
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	next := &nextStubEngine{}
+	ns := "denied-color-ns"
+
+	e, err := NewRequestColorLimiterEngine(client, "denied-p1", 1, []int{1}, time.Minute, ns, next)
+	assert.NoError(t, err)
+
+	reqP1 := newRequestColorLimiterTestRequest(t, ns, 1)
+	_, err = e.Process(reqP1)
+	assert.NoError(t, err)
+	assertLimiterAllow(t, reqP1, 1)
+
+	reqP1Denied := newRequestColorLimiterTestRequest(t, ns, 1)
+	_, err = e.Process(reqP1Denied)
+	assert.ErrorIs(t, err, ErrRateLimitReached)
+	assertLimiterDeny(t, reqP1Denied, 1)
+
+	e0, err := NewRequestColorLimiterEngine(client, "denied-p0", 10, []int{1}, time.Minute, ns, next)
+	assert.NoError(t, err)
+
+	reqP0 := newRequestColorLimiterTestRequest(t, ns, 0)
+	_, err = e0.Process(reqP0)
+	assert.NoError(t, err)
+	assertLimiterAllow(t, reqP0, 0)
+
+	reqP0Denied := newRequestColorLimiterTestRequest(t, ns, 0)
+	_, err = e0.Process(reqP0Denied)
+	assert.ErrorIs(t, err, ErrRateLimitReached)
+	assertLimiterDeny(t, reqP0Denied, 0)
 }
 
 func TestRequestColorLimiter_MarkerChain(t *testing.T) {
@@ -144,6 +187,8 @@ func TestRequestColorLimiter_MarkerChain(t *testing.T) {
 	marker, err := NewRequestColorMarkerEngine(client, "chain-marker", []int{2, 5, 10}, time.Minute, ns, limiter)
 	assert.NoError(t, err)
 
+	wantPriority := []int{2, 2, 1, 1, 1, 1, 1, 0}
+
 	// Expect 8 through: 2 p2 + 5 p1 + 1 p0
 	for i := 0; i < 8; i++ {
 		req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://example.com", strings.NewReader("body"))
@@ -151,6 +196,8 @@ func TestRequestColorLimiter_MarkerChain(t *testing.T) {
 		resp, err := marker.Process(r)
 		assert.NoError(t, err)
 		assert.NotNil(t, resp)
+		assertMarkerAllow(t, r, wantPriority[i])
+		assertLimiterAllow(t, r, wantPriority[i])
 	}
 	assert.Equal(t, 8, next.callCount)
 
@@ -159,6 +206,8 @@ func TestRequestColorLimiter_MarkerChain(t *testing.T) {
 	r := octollm.NewRequest(req, octollm.APIFormatUnknown)
 	_, err = marker.Process(r)
 	assert.Error(t, err)
+	assertMarkerAllow(t, r, 0)
+	assertLimiterDeny(t, r, 0)
 	assert.Equal(t, 8, next.callCount)
 }
 
@@ -181,11 +230,15 @@ func TestRequestColorLimiter_NoPriorityDefaultsToLowest(t *testing.T) {
 		resp, err := e.Process(r)
 		assert.NoError(t, err)
 		assert.NotNil(t, resp)
+		assertLimiterAllow(t, r, 0)
 	}
 	assert.Equal(t, 2, next.callCount)
 
 	// 3rd rejected
-	_, err = e.Process(r)
+	req3, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://example.com", strings.NewReader("body"))
+	r3 := octollm.NewRequest(req3, octollm.APIFormatUnknown)
+	_, err = e.Process(r3)
 	assert.Error(t, err)
+	assertLimiterDeny(t, r3, 0)
 	assert.Equal(t, 2, next.callCount)
 }

--- a/pkg/engines/limiter/request_color_marker.go
+++ b/pkg/engines/limiter/request_color_marker.go
@@ -2,6 +2,7 @@ package limiter
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"math"
@@ -121,12 +122,11 @@ func NewRequestColorMarkerEngine(redisClient *redis.Client, keyPrefix string, li
 	}, nil
 }
 
-// allow attempts to consume tokens from token buckets, trying from highest to lowest priority tier
-// Returns the achieved priority level and a done function
-func (e *RequestColorMarkerEngine) allow(ctx context.Context) (newCtx context.Context, done func(), err error) {
+// Pass-through returns ctx unchanged, nil err, priority 0 (Process stores p0).
+func (e *RequestColorMarkerEngine) allow(ctx context.Context) (newCtx context.Context, done func(), err error, priority int) {
 	// If configuration is invalid, directly pass through
 	if len(e.limits) == 0 || e.redisClient == nil || e.tokenBucketScript == nil {
-		return ctx, func() {}, nil
+		return ctx, func() {}, nil, 0
 	}
 
 	now := time.Now()
@@ -154,24 +154,24 @@ func (e *RequestColorMarkerEngine) allow(ctx context.Context) (newCtx context.Co
 	result, err := e.tokenBucketScript.Run(ctx, e.redisClient, keys, args...).Result()
 	if err != nil {
 		slog.ErrorContext(ctx, fmt.Sprintf("[RequestColorMarkerEngine] token bucket script error: %v, keyPrefix: %s", err, e.keyPrefix))
-		return ctx, func() {}, fmt.Errorf("token bucket script error: %w", err)
+		return ctx, func() {}, fmt.Errorf("token bucket script error: %w", err), 0
 	}
 
 	results, ok := result.([]interface{})
 	if !ok || len(results) < 2 {
 		slog.ErrorContext(ctx, fmt.Sprintf("[RequestColorMarkerEngine] unexpected script result format, keyPrefix: %s", e.keyPrefix))
-		return ctx, func() {}, fmt.Errorf("unexpected script result format")
+		return ctx, func() {}, fmt.Errorf("unexpected script result format"), 0
 	}
 
 	acquired, _ := results[0].(int64)
 	if acquired == 0 {
 		// All tiers exhausted
 		slog.WarnContext(ctx, fmt.Sprintf("[RequestColorMarkerEngine] all tiers exhausted, keyPrefix: %s", e.keyPrefix))
-		return ctx, func() {}, ErrRateLimitReached
+		return ctx, func() {}, ErrRateLimitReached, 0
 	}
 
 	// acquired > 0: priority (1-based in Lua, convert to 0-based)
-	priority := int(acquired) - 1
+	priority = int(acquired) - 1
 	acquiredTierIdx := numTiers - 1 - priority
 
 	// Set priority to context
@@ -179,21 +179,22 @@ func (e *RequestColorMarkerEngine) allow(ctx context.Context) (newCtx context.Co
 
 	slog.InfoContext(ctx, fmt.Sprintf("[RequestColorMarkerEngine] request allowed with priority %d (tier %d)", priority, acquiredTierIdx))
 	done = func() {}
-	return newCtx, done, nil
+	return newCtx, done, nil, priority
 }
 
 func (e *RequestColorMarkerEngine) Process(req *octollm.Request) (*octollm.Response, error) {
 	ctx := req.Context()
 
-	// Use allow method to perform rate limiting and priority marking
-	newCtx, done, err := e.allow(ctx)
+	newCtx, done, err, priority := e.allow(ctx)
 	if err != nil {
 		slog.ErrorContext(ctx, fmt.Sprintf("[RequestColorMarkerEngine] marker error: %v, keyPrefix: %s", err, e.keyPrefix))
+		if errors.Is(err, ErrRateLimitReached) {
+			recordMarkerDeny(req, priority)
+		}
 		return nil, err
 	}
-
-	// Use WithContext method to set new context with priority
 	req = req.WithContext(newCtx)
+	recordMarkerAllow(req, priority)
 
 	// Process request
 	resp, err := e.next.Process(req)

--- a/pkg/engines/limiter/request_color_marker_test.go
+++ b/pkg/engines/limiter/request_color_marker_test.go
@@ -66,6 +66,7 @@ func TestRequestColorMarker_PassThroughWhenDisabled(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, 1, next.callCount)
+	assertMarkerAllow(t, req, 0)
 }
 
 func TestRequestColorMarker_MultiTier_AcquirePriority(t *testing.T) {
@@ -85,6 +86,7 @@ func TestRequestColorMarker_MultiTier_AcquirePriority(t *testing.T) {
 		resp, err := e.Process(req)
 		assert.NoError(t, err)
 		assert.NotNil(t, resp)
+		assertMarkerAllow(t, req, 2)
 	}
 	assert.Equal(t, 2, next.callCount)
 
@@ -93,6 +95,7 @@ func TestRequestColorMarker_MultiTier_AcquirePriority(t *testing.T) {
 		resp, err := e.Process(req)
 		assert.NoError(t, err)
 		assert.NotNil(t, resp)
+		assertMarkerAllow(t, req, 1)
 	}
 	assert.Equal(t, 7, next.callCount)
 
@@ -101,6 +104,7 @@ func TestRequestColorMarker_MultiTier_AcquirePriority(t *testing.T) {
 		resp, err := e.Process(req)
 		assert.NoError(t, err)
 		assert.NotNil(t, resp)
+		assertMarkerAllow(t, req, 0)
 	}
 	assert.Equal(t, 17, next.callCount)
 
@@ -109,6 +113,7 @@ func TestRequestColorMarker_MultiTier_AcquirePriority(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 	assert.ErrorIs(t, err, ErrRateLimitReached)
+	assertMarkerDeny(t, req, 0)
 	assert.Equal(t, 17, next.callCount)
 }
 


### PR DESCRIPTION
Expose GetMarkerResult and GetLimiterResult for downstream use; marker allow returns priority and engines record pN via context. Pass-through engines treat outcome as p0. Add package-internal setMarkerResult and setLimiterResult wrapping req.WithContext.