### PR TITLE
feat(types): support string content in Responses input items

### DIFF
--- a/pkg/engines/moderator/ali_service.go
+++ b/pkg/engines/moderator/ali_service.go
@@ -229,7 +229,6 @@ func (s *AliModeratorService) Allow(ctx context.Context, text []rune) error {
 		}
 	}
 
-	slog.DebugContext(ctx, fmt.Sprintf("[AliModeratorService.Allow] content passed moderation"))
 	result, status = ModerationResultAllowed, ModerationRequestSuccess
 	return nil
 }

--- a/pkg/engines/moderator/moderator.go
+++ b/pkg/engines/moderator/moderator.go
@@ -181,23 +181,31 @@ func (e *TextModeratorEngine) Process(req *octollm.Request) (*octollm.Response, 
 		textBuffer := make([]rune, 0)
 		chunkBuffer := make([]*octollm.StreamChunk, 0, moderateEvery)
 		chunkCountSinceLast := 0
+		streamChunkCount := 0
+		defer func() {
+			attrs := []any{
+				"chunks", streamChunkCount,
+				"blocked", moderationFailedErr != nil,
+			}
+			if moderationFailedErr != nil {
+				attrs = append(attrs, "err", moderationFailedErr.Error())
+			}
+			slog.DebugContext(ctx, "[moderate] stream output moderation finished", attrs...)
+		}()
 
-		slog.DebugContext(ctx, fmt.Sprintf("[moderate] begin reading upstream stream"))
 		for chunk := range originalChunks.Chan() {
-			// slog.DebugContext(ctx, fmt.Sprintf("[moderate] stream chunk"))
 			text, err := e.TextModeratorAdapter.ExtractTextFromBody(ctx, chunk.Body)
 			if err != nil {
 				// stream done 是正常结束信号，不应该视为错误
 				if errors.Is(err, octollm.ErrStreamDone) {
 					chunkBuffer = append(chunkBuffer, chunk)
-					slog.DebugContext(ctx, fmt.Sprintf("stream done, will process remaining chunks"))
+					streamChunkCount++
 					break
 				}
-				slog.DebugContext(ctx, fmt.Sprintf("extract text from stream chunk error: %s", err))
 				moderationFailedErr = fmt.Errorf("%w: %w", ErrModeratorInternalError, err)
 				break
 			}
-			// slog.DebugContext(ctx, fmt.Sprintf("[moderate] extract text from stream chunk: %s", string(text)))
+			streamChunkCount++
 			textBuffer = append(textBuffer, text...)
 			if len(textBuffer) > maxRuneLen {
 				// truncate text to last max rune len
@@ -209,7 +217,6 @@ func (e *TextModeratorEngine) Process(req *octollm.Request) (*octollm.Response, 
 				textBufferTrimmed := trimRune(textBuffer)
 				if len(textBufferTrimmed) != 0 && moderationSampleHit(e.OutputModerationSampleRate) {
 					if err := e.ModeratorService.Allow(ctx, textBufferTrimmed); err != nil {
-						slog.DebugContext(ctx, fmt.Sprintf("moderate stream chunk error: %s", err))
 						moderationFailedErr = fmt.Errorf("%w: %w", ErrOutputNotAllowed, err)
 						break
 					}
@@ -228,11 +235,9 @@ func (e *TextModeratorEngine) Process(req *octollm.Request) (*octollm.Response, 
 
 		// Handle remaining chunks after stream ends
 		if moderationFailedErr == nil && len(chunkBuffer) > 0 {
-			slog.DebugContext(ctx, fmt.Sprintf("[moderate] processing %d remaining chunks", len(chunkBuffer)))
 			textBufferTrimmed := trimRune(textBuffer)
 			if len(textBufferTrimmed) != 0 && moderationSampleHit(e.OutputModerationSampleRate) {
 				if err := e.ModeratorService.Allow(ctx, textBufferTrimmed); err != nil {
-					slog.DebugContext(ctx, fmt.Sprintf("moderate remaining stream chunks error: %s", err))
 					moderationFailedErr = fmt.Errorf("%w: %w", ErrOutputNotAllowed, err)
 				}
 			}

--- a/pkg/engines/moderator/netease_service.go
+++ b/pkg/engines/moderator/netease_service.go
@@ -136,7 +136,6 @@ func (s *NeteaseModeratorService) Allow(ctx context.Context, text []rune) error 
 		}
 
 		// Allow content to pass in other cases
-		slog.DebugContext(ctx, fmt.Sprintf("[NeteaseModeratorService.Allow] content passed moderation, suggestion: %d", suggestion))
 		result, status = ModerationResultAllowed, ModerationRequestSuccess
 		return nil
 	}

--- a/pkg/engines/moderator/openai_adapter_test.go
+++ b/pkg/engines/moderator/openai_adapter_test.go
@@ -486,7 +486,7 @@ func TestUniversalAdapter_ResponsesFormat(t *testing.T) {
 				Items: []*openai.ResponsesInputItem{
 					{
 						Role: "user",
-						Content: []*openai.ResponsesInputContentItem{
+						Content: openai.ResponsesInputContentArray{
 							{Type: "input_text", Text: "hello responses"},
 						},
 					},

--- a/pkg/types/openai/responses_req.go
+++ b/pkg/types/openai/responses_req.go
@@ -89,23 +89,6 @@ func (i *ResponsesInputItem) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (i ResponsesInputItem) MarshalJSON() ([]byte, error) {
-	type Alias struct {
-		Role    string          `json:"role,omitempty"`
-		Content json.RawMessage `json:"content,omitempty"`
-	}
-
-	alias := Alias{Role: i.Role}
-	if i.Content != nil {
-		contentBytes, err := json.Marshal(i.Content)
-		if err != nil {
-			return nil, err
-		}
-		alias.Content = contentBytes
-	}
-	return json.Marshal(alias)
-}
-
 func (i *ResponsesInputItem) ExtractText() string {
 	if i == nil || i.Content == nil {
 		return ""
@@ -124,10 +107,6 @@ type ResponsesInputContentString string
 
 func (c ResponsesInputContentString) ExtractText() string { return string(c) }
 
-func (c ResponsesInputContentString) MarshalJSON() ([]byte, error) {
-	return json.Marshal(string(c))
-}
-
 type ResponsesInputContentArray []*ResponsesInputContentItem
 
 func (c ResponsesInputContentArray) ExtractText() string {
@@ -139,10 +118,6 @@ func (c ResponsesInputContentArray) ExtractText() string {
 		text += part.ExtractText()
 	}
 	return text
-}
-
-func (c ResponsesInputContentArray) MarshalJSON() ([]byte, error) {
-	return json.Marshal([]*ResponsesInputContentItem(c))
 }
 
 func unmarshalResponsesInputContent(data json.RawMessage) (ResponsesInputContent, error) {

--- a/pkg/types/openai/responses_req.go
+++ b/pkg/types/openai/responses_req.go
@@ -63,23 +63,99 @@ func (r ResponsesInput) ExtractText() string {
 }
 
 type ResponsesInputItem struct {
-	Role    string                       `json:"role,omitempty"`
-	Content []*ResponsesInputContentItem `json:"content,omitempty"`
+	Role    string                `json:"role,omitempty"`
+	Content ResponsesInputContent `json:"content,omitempty"`
+}
+
+func (i *ResponsesInputItem) UnmarshalJSON(data []byte) error {
+	type Alias struct {
+		Role    string          `json:"role,omitempty"`
+		Content json.RawMessage `json:"content,omitempty"`
+	}
+
+	var alias Alias
+	if err := json.Unmarshal(data, &alias); err != nil {
+		return err
+	}
+
+	i.Role = alias.Role
+	if len(alias.Content) > 0 {
+		content, err := unmarshalResponsesInputContent(alias.Content)
+		if err != nil {
+			return err
+		}
+		i.Content = content
+	}
+	return nil
+}
+
+func (i ResponsesInputItem) MarshalJSON() ([]byte, error) {
+	type Alias struct {
+		Role    string          `json:"role,omitempty"`
+		Content json.RawMessage `json:"content,omitempty"`
+	}
+
+	alias := Alias{Role: i.Role}
+	if i.Content != nil {
+		contentBytes, err := json.Marshal(i.Content)
+		if err != nil {
+			return nil, err
+		}
+		alias.Content = contentBytes
+	}
+	return json.Marshal(alias)
 }
 
 func (i *ResponsesInputItem) ExtractText() string {
-	if i == nil {
+	if i == nil || i.Content == nil {
 		return ""
 	}
+	return i.Content.ExtractText()
+}
 
+// ResponsesInputContent supports OpenAI Responses input item `content` polymorphism:
+// - string
+// - array of content parts (input_text, input_image, ...)
+type ResponsesInputContent interface {
+	ExtractText() string
+}
+
+type ResponsesInputContentString string
+
+func (c ResponsesInputContentString) ExtractText() string { return string(c) }
+
+func (c ResponsesInputContentString) MarshalJSON() ([]byte, error) {
+	return json.Marshal(string(c))
+}
+
+type ResponsesInputContentArray []*ResponsesInputContentItem
+
+func (c ResponsesInputContentArray) ExtractText() string {
 	text := ""
-	for _, part := range i.Content {
+	for _, part := range c {
 		if part == nil {
 			continue
 		}
 		text += part.ExtractText()
 	}
 	return text
+}
+
+func (c ResponsesInputContentArray) MarshalJSON() ([]byte, error) {
+	return json.Marshal([]*ResponsesInputContentItem(c))
+}
+
+func unmarshalResponsesInputContent(data json.RawMessage) (ResponsesInputContent, error) {
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		return ResponsesInputContentString(s), nil
+	}
+
+	var items []*ResponsesInputContentItem
+	if err := json.Unmarshal(data, &items); err != nil {
+		return nil, err
+	}
+	return ResponsesInputContentArray(items), nil
 }
 
 type ResponsesInputContentItem struct {

--- a/pkg/types/openai/responses_req_test.go
+++ b/pkg/types/openai/responses_req_test.go
@@ -43,6 +43,11 @@ func TestResponsesRequest_Input_StringAndArray(t *testing.T) {
 			raw: `{"model":"gpt-5.4","input":[{"role":"user","content":[{"type":"input_image","image_url":{"url":"https://example.com/b.jpg","detail":"high"}}]}]}`,
 			want: "https://example.com/b.jpg",
 		},
+		{
+			name: "input array with string content",
+			raw:  `{"model":"gpt-5.4","input":[{"role":"user","content":"plain text message"}]}`,
+			want: "plain text message",
+		},
 	}
 
 	for _, tt := range tests {
@@ -58,6 +63,99 @@ func TestResponsesRequest_Input_StringAndArray(t *testing.T) {
 				t.Fatalf("ExtractText()=%q want=%q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestResponsesInputContent_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "string",
+			raw:  `"hello"`,
+			want: "hello",
+		},
+		{
+			name: "array",
+			raw:  `[{"type":"input_text","text":"hi"},{"type":"input_image","image_url":"https://example.com/x.png"}]`,
+			want: "hihttps://example.com/x.png",
+		},
+		{
+			name:    "invalid number",
+			raw:     `42`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var content ResponsesInputContent
+			var item ResponsesInputItem
+			if err := json.Unmarshal([]byte(`{"role":"user","content":`+tt.raw+`}`), &item); err != nil {
+				if tt.wantErr {
+					return
+				}
+				t.Fatal(err)
+			}
+			content = item.Content
+			if tt.wantErr {
+				t.Fatal("expected error")
+			}
+			if got := content.ExtractText(); got != tt.want {
+				t.Fatalf("ExtractText()=%q want=%q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResponsesInputContent_MarshalRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{name: "string", raw: `{"role":"user","content":"round trip"}`},
+		{name: "array", raw: `{"role":"user","content":[{"type":"input_text","text":"round trip"}]}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var item ResponsesInputItem
+			if err := json.Unmarshal([]byte(tt.raw), &item); err != nil {
+				t.Fatal(err)
+			}
+			out, err := json.Marshal(item)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var again ResponsesInputItem
+			if err := json.Unmarshal(out, &again); err != nil {
+				t.Fatal(err)
+			}
+			if item.Content.ExtractText() != again.Content.ExtractText() {
+				t.Fatalf("before=%q after=%q", item.Content.ExtractText(), again.Content.ExtractText())
+			}
+		})
+	}
+}
+
+func TestResponsesInputItem_ContentStringThenArray(t *testing.T) {
+	var item ResponsesInputItem
+
+	if err := json.Unmarshal([]byte(`{"role":"user","content":"first"}`), &item); err != nil {
+		t.Fatal(err)
+	}
+	if got := item.Content.ExtractText(); got != "first" {
+		t.Fatalf("string content: got %q", got)
+	}
+
+	if err := json.Unmarshal([]byte(`{"role":"user","content":[{"type":"input_text","text":"second"}]}`), &item); err != nil {
+		t.Fatal(err)
+	}
+	if got := item.Content.ExtractText(); got != "second" {
+		t.Fatalf("array content after string: got %q", got)
 	}
 }
 

--- a/pkg/types/openai/responses_req_test.go
+++ b/pkg/types/openai/responses_req_test.go
@@ -111,13 +111,113 @@ func TestResponsesInputContent_UnmarshalJSON(t *testing.T) {
 	}
 }
 
+func TestResponsesInputItem_MarshalJSON_StringContent(t *testing.T) {
+	item := ResponsesInputItem{
+		Role:    "user",
+		Content: ResponsesInputContentString("Hello, responses!"),
+	}
+
+	data, err := json.Marshal(item)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatal(err)
+	}
+	if result["role"] != "user" {
+		t.Errorf("role: got %v", result["role"])
+	}
+	content, ok := result["content"].(string)
+	if !ok {
+		t.Fatalf("content should be JSON string, got %T (%v)", result["content"], result["content"])
+	}
+	if content != "Hello, responses!" {
+		t.Errorf("content: got %q", content)
+	}
+}
+
+func TestResponsesInputItem_MarshalJSON_ArrayContent(t *testing.T) {
+	item := ResponsesInputItem{
+		Role: "user",
+		Content: ResponsesInputContentArray([]*ResponsesInputContentItem{
+			{Type: "input_text", Text: "Hello"},
+			{Type: "input_image", ImageURL: ImageURLString("https://example.com/a.png")},
+		}),
+	}
+
+	data, err := json.Marshal(item)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatal(err)
+	}
+	if result["role"] != "user" {
+		t.Errorf("role: got %v", result["role"])
+	}
+	content, ok := result["content"].([]interface{})
+	if !ok {
+		t.Fatalf("content should be JSON array, got %T (%v)", result["content"], result["content"])
+	}
+	if len(content) != 2 {
+		t.Fatalf("content array length: got %d want 2", len(content))
+	}
+
+	first, ok := content[0].(map[string]interface{})
+	if !ok || first["type"] != "input_text" || first["text"] != "Hello" {
+		t.Fatalf("first part: %+v", content[0])
+	}
+	second, ok := content[1].(map[string]interface{})
+	if !ok || second["type"] != "input_image" {
+		t.Fatalf("second part: %+v", content[1])
+	}
+	if second["image_url"] != "https://example.com/a.png" {
+		t.Fatalf("image_url: got %v", second["image_url"])
+	}
+}
+
 func TestResponsesInputContent_MarshalRoundTrip(t *testing.T) {
 	tests := []struct {
-		name string
-		raw  string
+		name       string
+		raw        string
+		assertJSON func(t *testing.T, content interface{})
 	}{
-		{name: "string", raw: `{"role":"user","content":"round trip"}`},
-		{name: "array", raw: `{"role":"user","content":[{"type":"input_text","text":"round trip"}]}`},
+		{
+			name: "string",
+			raw:  `{"role":"user","content":"round trip"}`,
+			assertJSON: func(t *testing.T, content interface{}) {
+				t.Helper()
+				s, ok := content.(string)
+				if !ok {
+					t.Fatalf("content should be string, got %T", content)
+				}
+				if s != "round trip" {
+					t.Fatalf("content=%q want round trip", s)
+				}
+			},
+		},
+		{
+			name: "array",
+			raw:  `{"role":"user","content":[{"type":"input_text","text":"round trip"}]}`,
+			assertJSON: func(t *testing.T, content interface{}) {
+				t.Helper()
+				parts, ok := content.([]interface{})
+				if !ok {
+					t.Fatalf("content should be array, got %T", content)
+				}
+				if len(parts) != 1 {
+					t.Fatalf("content array length: got %d want 1", len(parts))
+				}
+				part, ok := parts[0].(map[string]interface{})
+				if !ok || part["type"] != "input_text" || part["text"] != "round trip" {
+					t.Fatalf("content part: %+v", parts[0])
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -130,12 +230,22 @@ func TestResponsesInputContent_MarshalRoundTrip(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+
+			var marshaled map[string]interface{}
+			if err := json.Unmarshal(out, &marshaled); err != nil {
+				t.Fatal(err)
+			}
+			if marshaled["role"] != "user" {
+				t.Fatalf("role: got %v", marshaled["role"])
+			}
+			tt.assertJSON(t, marshaled["content"])
+
 			var again ResponsesInputItem
 			if err := json.Unmarshal(out, &again); err != nil {
 				t.Fatal(err)
 			}
 			if item.Content.ExtractText() != again.Content.ExtractText() {
-				t.Fatalf("before=%q after=%q", item.Content.ExtractText(), again.Content.ExtractText())
+				t.Fatalf("ExtractText before=%q after=%q", item.Content.ExtractText(), again.Content.ExtractText())
 			}
 		})
 	}


### PR DESCRIPTION
OpenAI Responses API allows input[].content as a string or array; add polymorphic unmarshaling and tests aligned with MessageContent.