### PR TITLE
feat(client): make SSE scanner max token size configurable

### DIFF
--- a/pkg/engines/client/http.go
+++ b/pkg/engines/client/http.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -261,7 +260,7 @@ func (e *HTTPEndpoint) processSSEStream(ctx context.Context, req *octollm.Reques
 	var recvFirstChunkTime time.Time
 
 	var totalChunkSent int
-	scanner := bufio.NewScanner(resp.Body)
+	scanner := newScanner(resp.Body)
 	for scanner.Scan() {
 		if err := ctx.Err(); err != nil {
 			slog.InfoContext(ctx, fmt.Sprintf("[http-endpoint] context error during stream response: %v", err))

--- a/pkg/engines/client/http_test.go
+++ b/pkg/engines/client/http_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/infinigence/octollm/pkg/internal/testhelper"
 	"github.com/infinigence/octollm/pkg/octollm"
@@ -169,4 +170,40 @@ data: {"type":"message_stop"}
 	got, err := testhelper.CollectSSEStream(stream, 5*time.Second)
 	assert.NoError(t, err)
 	assert.Equal(t, string(got), sseStreamNormalized)
+}
+
+func TestProcessSSEStream_LongDataLine(t *testing.T) {
+	payload := strings.Repeat("x", 100*1024)
+	sseStream := "data: " + payload + "\n\n"
+
+	resp := &http.Response{
+		Body: io.NopCloser(strings.NewReader(sseStream)),
+	}
+
+	ch := make(chan *octollm.StreamChunk, 2)
+	parser := &octollm.JSONParser[json.RawMessage]{}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	oldSize := ScannerMaxTokenSize()
+	SetScannerMaxTokenSize(200 * 1024)
+	t.Cleanup(func() { SetScannerMaxTokenSize(oldSize) })
+
+	endpoint := NewHTTPEndpoint()
+	req := testhelper.CreateTestRequest()
+
+	go endpoint.processSSEStream(ctx, req, resp, ch, parser)
+
+	var chunks []*octollm.StreamChunk
+	for chunk := range ch {
+		chunks = append(chunks, chunk)
+	}
+
+	require.Len(t, chunks, 1)
+	body, err := chunks[0].Body.Bytes()
+	require.NoError(t, err)
+	assert.Equal(t, payload, string(body))
+
+	_, scanErr := GetClientProcessStreamError(req)
+	assert.False(t, scanErr)
 }

--- a/pkg/engines/client/scanner.go
+++ b/pkg/engines/client/scanner.go
@@ -1,0 +1,29 @@
+package client
+
+import (
+	"bufio"
+	"io"
+)
+
+var scannerMaxTokenSize = bufio.MaxScanTokenSize
+
+// SetScannerMaxTokenSize sets the maximum token size for SSE stream scanners created after this call.
+// Non-positive values are ignored.
+func SetScannerMaxTokenSize(size int) {
+	if size <= 0 {
+		return
+	}
+	scannerMaxTokenSize = size
+}
+
+// ScannerMaxTokenSize returns the package-level maximum scan token size for SSE scanners.
+func ScannerMaxTokenSize() int {
+	return scannerMaxTokenSize
+}
+
+func newScanner(r io.Reader) *bufio.Scanner {
+	scanner := bufio.NewScanner(r)
+	buf := make([]byte, 0, 4096)
+	scanner.Buffer(buf, scannerMaxTokenSize)
+	return scanner
+}

--- a/pkg/engines/client/scanner_test.go
+++ b/pkg/engines/client/scanner_test.go
@@ -1,0 +1,53 @@
+package client
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetScannerMaxTokenSize_AppliesToNewScanners(t *testing.T) {
+	old := ScannerMaxTokenSize()
+	t.Cleanup(func() { SetScannerMaxTokenSize(old) })
+
+	longLine := strings.Repeat("a", bufio.MaxScanTokenSize+1)
+
+	SetScannerMaxTokenSize(bufio.MaxScanTokenSize)
+	scanner := newScanner(strings.NewReader(longLine + "\n"))
+	require.False(t, scanner.Scan())
+	assert.ErrorContains(t, scanner.Err(), "token too long")
+
+	SetScannerMaxTokenSize(200 * 1024)
+	scanner = newScanner(strings.NewReader(longLine + "\n"))
+	require.True(t, scanner.Scan())
+	assert.Equal(t, longLine, string(scanner.Bytes()))
+	assert.NoError(t, scanner.Err())
+}
+
+func TestNewScanner_ErrorsWhenTokenExceedsSmallLimit(t *testing.T) {
+	old := ScannerMaxTokenSize()
+	t.Cleanup(func() { SetScannerMaxTokenSize(old) })
+
+	const limit = 4 * 1024
+	SetScannerMaxTokenSize(limit)
+
+	// One byte over limit; fills the 4096-byte initial buffer and triggers ErrTooLong on grow.
+	line := strings.Repeat("x", limit+1)
+	scanner := newScanner(strings.NewReader(line + "\n"))
+	require.False(t, scanner.Scan())
+	assert.ErrorContains(t, scanner.Err(), "token too long")
+}
+
+func TestSetScannerMaxTokenSize_IgnoresNonPositive(t *testing.T) {
+	old := ScannerMaxTokenSize()
+	t.Cleanup(func() { SetScannerMaxTokenSize(old) })
+
+	SetScannerMaxTokenSize(128 * 1024)
+	SetScannerMaxTokenSize(0)
+	assert.Equal(t, 128*1024, ScannerMaxTokenSize())
+	SetScannerMaxTokenSize(-1)
+	assert.Equal(t, 128*1024, ScannerMaxTokenSize())
+}


### PR DESCRIPTION
Add client-scoped scanner helpers with a 4KB initial buffer that grows up to a tunable limit, and cover long SSE data lines plus limit errors.