### PR TITLE
feat(load-balancer): reserve cache-hit headroom in shard-key concurrency LB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,10 @@
 .idea/
 *.iml
 .vscode/
+
 .claude/*.local.*
+CLAUDE.local.md
+
 .cursor/
 CLAUDE.local.md
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,8 +58,10 @@ Engines can be arbitrarily nested, each handling specific concerns (client commu
 - **`/pkg/exprenv`** - expr-lang environment for rule/rewrite expressions; exposes `req.Header()`, `req.Feature()`, `req.Context()`, `req.RawReq()`; `exprenv.Get(req)` retrieves or creates the env from request context, `exprenv.Sentinel` is a zero-value env used for compile-time type checking
 - **`/pkg/composer`** - YAML config parsing, model-to-engine mapping, orchestration
 - **`/pkg/errutils`** - Custom error types (`UpstreamHTTPError` vs handler errors)
-- **`/pkg/types/anthropic`** - Claude message request/response types
+- **`/pkg/types/anthropic`** - Claude message request/response types; `docs/api-create-snap*.md` is a dated snapshot of Anthropic's official Create Message API spec — the source-of-truth to model these types against (consult the latest snapshot when adding/editing fields)
 - **`/pkg/types/openai`** - OpenAI ChatCompletion types
+- **`/pkg/types/UNION_TYPES.md`** - READ before adding/editing any `/pkg/types` type: the polymorphic-JSON convention (Interface + `xxxField` pattern, dispatch, marshaling)
+- **`/pkg/types/TESTING_GUIDE.md`** - READ before testing those types: table-driven Marshal/Unmarshal conventions
 - **`/cmd/octollm-server`** - Standalone server entry point with Gin routes and auth middleware
 
 ### Request Flow

--- a/pkg/engines/load-balancer/round_robin.go
+++ b/pkg/engines/load-balancer/round_robin.go
@@ -20,6 +20,10 @@ type BackendItem struct {
 	// MaxConcurrencyFn is optional; ShardKeyConcurrency uses it as the request-time ratio denominator.
 	// When nil, ShardKeyConcurrency wraps Weight as a static denominator.
 	MaxConcurrencyFn ShardMaxConcurrencyFn
+	// CacheMissMaxUtilization is the per-backend concurrency utilization (count/maxConcurrency) ceiling
+	// above which non-strong-cache-hit requests are denied headroom on this backend. A value >= 1.0
+	// (or <= 0) disables the headroom reservation for the backend. Only ShardKeyConcurrency uses it.
+	CacheMissMaxUtilization float64
 }
 
 type wrrBackend struct {

--- a/pkg/engines/load-balancer/shard_key_concurrency.go
+++ b/pkg/engines/load-balancer/shard_key_concurrency.go
@@ -2,6 +2,7 @@ package loadbalancer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"math"
@@ -12,6 +13,11 @@ import (
 
 	"github.com/infinigence/octollm/pkg/octollm"
 )
+
+// ErrCacheMissHeadroom is returned when a cache-miss request cannot be served because every
+// candidate backend is at or above cacheMissMaxUtilization — only the reserved headroom remains,
+// and it is restricted to cache-hit (last-two-shard-key) requests.
+var ErrCacheMissHeadroom = errors.New("cache-miss request rejected to preserve cache-hit headroom")
 
 // ShardMaxConcurrencyFn returns the capacity denominator for concurrency ratio (count/denom).
 // When non-nil, each value—including 0—is used directly (no fallback to BackendItem.Weight).
@@ -25,6 +31,14 @@ type concurrencyBackend struct {
 	// maxConcurrencyFn supplies the ratio denominator per request. It is always set by construction:
 	// dynamic backends use BackendItem.MaxConcurrencyFn, static backends use a closure over Weight.
 	maxConcurrencyFn ShardMaxConcurrencyFn
+}
+
+// prioritizedBackend pairs a shard-key-resolved backend with whether it was resolved from one of the
+// top two (highest-priority) shard keys. strongCacheHit backends are high-confidence cache hits and
+// bypass the headroom ceiling; non-strongCacheHit backends are subject to cacheMissMaxUtilization.
+type prioritizedBackend struct {
+	backend        *concurrencyBackend
+	strongCacheHit bool
 }
 
 // ShardKeyConcurrency implements a load balancer that:
@@ -46,6 +60,12 @@ type ShardKeyConcurrency struct {
 
 	retryTimeout  time.Duration
 	retryMaxCount int
+
+	// cacheMissMaxUtilization is the concurrency utilization (count/maxConcurrency) ceiling above
+	// which non-strong-cache-hit requests are denied headroom. Requests resolved from one of the last
+	// two shard keys are strong cache hits and bypass this ceiling; everything else (weak cache hits
+	// and full misses) is subject to it. A value >= 1.0 (or <= 0) disables the headroom reservation.
+	cacheMissMaxUtilization float64
 }
 
 var _ octollm.Engine = (*ShardKeyConcurrency)(nil)
@@ -63,6 +83,7 @@ var _ octollm.Engine = (*ShardKeyConcurrency)(nil)
 //   - redisClient: Redis client for shard-key ZSETs and concurrency ZCard
 //   - keyPrefix: prefix prepended to all Redis keys
 //   - concurrencyKeyFn: required; returns the Redis key used to track per-backend concurrency
+//   - cacheMissMaxUtilization: utilization ceiling for cache-miss requests; >= 1.0 disables headroom
 func NewShardKeyConcurrency(
 	backends []BackendItem,
 	retryTimeout time.Duration,
@@ -72,6 +93,7 @@ func NewShardKeyConcurrency(
 	redisClient *redis.Client,
 	keyPrefix string,
 	concurrencyKeyFn func(req *octollm.Request, backendName string) string,
+	cacheMissMaxUtilization float64,
 ) (*ShardKeyConcurrency, error) {
 	if redisClient == nil {
 		return nil, fmt.Errorf("redisClient must be provided")
@@ -105,14 +127,15 @@ func NewShardKeyConcurrency(
 	}
 
 	return &ShardKeyConcurrency{
-		backends:           cb,
-		shardKeyListGetter: shardKeyListGetter,
-		redisClient:        redisClient,
-		shardKeyTTL:        shardKeyTTL,
-		keyPrefix:          keyPrefix,
-		concurrencyKeyFn:   concurrencyKeyFn,
-		retryTimeout:       retryTimeout,
-		retryMaxCount:      retryMaxCount,
+		backends:                cb,
+		shardKeyListGetter:      shardKeyListGetter,
+		redisClient:             redisClient,
+		shardKeyTTL:             shardKeyTTL,
+		keyPrefix:               keyPrefix,
+		concurrencyKeyFn:        concurrencyKeyFn,
+		retryTimeout:            retryTimeout,
+		retryMaxCount:           retryMaxCount,
+		cacheMissMaxUtilization: cacheMissMaxUtilization,
 	}, nil
 }
 
@@ -128,7 +151,7 @@ func (l *ShardKeyConcurrency) redisKey(shardKey string) string {
 func (l *ShardKeyConcurrency) resolvePrioritizedBackends(
 	ctx context.Context,
 	shardKeyList []string,
-) []*concurrencyBackend {
+) []prioritizedBackend {
 	if len(shardKeyList) == 0 {
 		return nil
 	}
@@ -155,7 +178,7 @@ func (l *ShardKeyConcurrency) resolvePrioritizedBackends(
 	seen := make(map[string]bool)
 	trimPipe := l.redisClient.Pipeline()
 
-	var prioritized []*concurrencyBackend
+	var prioritized []prioritizedBackend
 	for i := len(shardKeyList) - 1; i >= 0; i-- {
 		cmd := cmds[i]
 		if cmd == nil {
@@ -172,12 +195,14 @@ func (l *ShardKeyConcurrency) resolvePrioritizedBackends(
 				trimPipe.ZRemRangeByRank(ctx, l.redisKey(shardKeyList[i]), 0, stop)
 			}
 		}
+		// Hits on either of the top two (highest-priority) shard keys count as strong cache hits.
+		strongCacheHit := i >= len(shardKeyList)-2
 		for _, name := range backendNames {
 			if name == "" || seen[name] {
 				continue
 			}
 			if b, ok := backendByName[name]; ok {
-				prioritized = append(prioritized, b)
+				prioritized = append(prioritized, prioritizedBackend{backend: b, strongCacheHit: strongCacheHit})
 				seen[name] = true
 			}
 		}
@@ -191,9 +216,10 @@ func (l *ShardKeyConcurrency) resolvePrioritizedBackends(
 }
 
 // selectByConcurrency picks the backend with the lowest currentConcurrency/maxConcurrency ratio
-// using Redis ZCard. Backends in excludeNames are skipped.
+// using Redis ZCard. Backends in excludeNames are skipped. The returned float is the selected
+// backend's utilization ratio (count/maxConcurrency); it is 0 on the random fallback path below.
 // Falls back to uniform random selection among backends with positive effective capacity if Redis Exec fails.
-func (l *ShardKeyConcurrency) selectByConcurrency(req *octollm.Request, excludeNames map[string]bool) (string, octollm.Engine) {
+func (l *ShardKeyConcurrency) selectByConcurrency(req *octollm.Request, excludeNames map[string]bool) (string, octollm.Engine, float64) {
 	ctx := req.Context()
 	candidates := make([]*concurrencyBackend, 0, len(l.backends))
 	for _, b := range l.backends {
@@ -203,7 +229,7 @@ func (l *ShardKeyConcurrency) selectByConcurrency(req *octollm.Request, excludeN
 		candidates = append(candidates, b)
 	}
 	if len(candidates) == 0 {
-		return "", nil
+		return "", nil, 0
 	}
 	rand.Shuffle(len(candidates), func(i, j int) { candidates[i], candidates[j] = candidates[j], candidates[i] })
 
@@ -221,10 +247,10 @@ func (l *ShardKeyConcurrency) selectByConcurrency(req *octollm.Request, excludeN
 			}
 		}
 		if len(usable) == 0 {
-			return "", nil
+			return "", nil, 0
 		}
 		b := usable[rand.Intn(len(usable))]
-		return b.name, b.engine
+		return b.name, b.engine, 0
 	}
 
 	minRatio := math.MaxFloat64
@@ -245,9 +271,31 @@ func (l *ShardKeyConcurrency) selectByConcurrency(req *octollm.Request, excludeN
 		}
 	}
 	if selected == nil {
-		return "", nil
+		return "", nil, 0
 	}
-	return selected.name, selected.engine
+	return selected.name, selected.engine, minRatio
+}
+
+// headroomEnabled reports whether cache-miss headroom reservation is active. A configured
+// utilization of <=0 or >=1.0 disables it (no headroom is reserved).
+func (l *ShardKeyConcurrency) headroomEnabled() bool {
+	return l.cacheMissMaxUtilization > 0 && l.cacheMissMaxUtilization < 1.0
+}
+
+// overHeadroom reports whether the backend's current concurrency utilization (count/maxConcurrency)
+// exceeds cacheMissMaxUtilization. It fails open: a Redis error returns false so requests are not
+// blocked by a transient failure. Callers must guard with headroomEnabled.
+func (l *ShardKeyConcurrency) overHeadroom(req *octollm.Request, b *concurrencyBackend) bool {
+	denom := b.maxConcurrencyFn(req)
+	if denom <= 0 {
+		return true
+	}
+	count, err := l.redisClient.ZCard(req.Context(), l.concurrencyKeyFn(req, b.name)).Result()
+	if err != nil {
+		slog.WarnContext(req.Context(), fmt.Sprintf("[ShardKey Concurrency load balancer] failed to ZCard concurrency for headroom check on %s: %v", b.name, err))
+		return false
+	}
+	return float64(count)/float64(denom) > l.cacheMissMaxUtilization
 }
 
 func (l *ShardKeyConcurrency) Process(req *octollm.Request) (*octollm.Response, error) {
@@ -265,23 +313,49 @@ func (l *ShardKeyConcurrency) Process(req *octollm.Request) (*octollm.Response, 
 
 	start := time.Now()
 	retryCount := 0
+	var lastResp *octollm.Response
+	var lastErr error
 	for {
 		var n string
 		var eng octollm.Engine
 
 		if prioritizedIndex < len(prioritized) {
-			b := prioritized[prioritizedIndex]
+			pb := prioritized[prioritizedIndex]
+			b := pb.backend
 			prioritizedIndex++
 			if b.maxConcurrencyFn(req) <= 0 {
 				slog.InfoContext(req.Context(),
 					fmt.Sprintf("[ShardKey Concurrency load balancer] skip prioritized backend with no effective capacity: %s (index %d/%d), shardKeys: %v", b.name, prioritizedIndex, len(prioritized), shardKeyList),
 					slog.String("backend_name", b.name),
 				)
+				excludeNames[b.name] = true
+				continue
+			}
+			// Weak cache hits (not top-two-shard-key) prioritized backends only get headroom up to
+			// cacheMissMaxUtilization; skip them once over so the reserved capacity stays for strong cache hits.
+			if !pb.strongCacheHit && l.headroomEnabled() && l.overHeadroom(req, b) {
+				slog.InfoContext(req.Context(),
+					fmt.Sprintf("[ShardKey Concurrency load balancer] skip weak-cache-hit prioritized backend over headroom %.2f: %s (index %d/%d), shardKeys: %v", l.cacheMissMaxUtilization, b.name, prioritizedIndex, len(prioritized), shardKeyList),
+					slog.String("backend_name", b.name),
+				)
+				excludeNames[b.name] = true
+				// Excluding this backend may have exhausted every backend (all were weak cache hits
+				// over the ceiling). That is a headroom rejection: nothing is left for a cache miss, so
+				// reject with the headroom sentinel (429) instead of falling through to an empty
+				// concurrency selection. On a failover, surface the previous error rather than masking it.
+				if len(excludeNames) >= len(l.backends) {
+					if retryCount > 0 {
+						slog.WarnContext(req.Context(), fmt.Sprintf("[ShardKey Concurrency load balancer] all backends over headroom %.2f on failover, returning previous error: %v", l.cacheMissMaxUtilization, lastErr))
+						return lastResp, lastErr
+					} else {
+						return nil, ErrCacheMissHeadroom
+					}
+				}
 				continue
 			}
 			n, eng = b.name, b.engine
 			slog.InfoContext(req.Context(),
-				fmt.Sprintf("[ShardKey Concurrency load balancer] prioritized backend hit: %s (index %d/%d), shardKeys: %v", n, prioritizedIndex, len(prioritized), shardKeyList),
+				fmt.Sprintf("[ShardKey Concurrency load balancer] prioritized backend hit (strongCacheHit=%t): %s (index %d/%d), shardKeys: %v", pb.strongCacheHit, n, prioritizedIndex, len(prioritized), shardKeyList),
 				slog.String("backend_name", n),
 			)
 		} else {
@@ -291,7 +365,18 @@ func (l *ShardKeyConcurrency) Process(req *octollm.Request) (*octollm.Response, 
 					candidates = append(candidates, b.name)
 				}
 			}
-			n, eng = l.selectByConcurrency(req, excludeNames)
+			var ratio float64
+			n, eng, ratio = l.selectByConcurrency(req, excludeNames)
+			// Full cache miss: selectByConcurrency picks the least-utilized backend, so if even that
+			// one is over the headroom ceiling, every backend is — reject to preserve headroom (429).
+			if eng != nil && l.headroomEnabled() && ratio > l.cacheMissMaxUtilization {
+				if retryCount > 0 {
+					slog.WarnContext(req.Context(), fmt.Sprintf("[ShardKey Concurrency load balancer] cache-miss over headroom %.2f on failover, returning previous error: %v", l.cacheMissMaxUtilization, lastErr))
+					return lastResp, lastErr
+				}
+				slog.WarnContext(req.Context(), fmt.Sprintf("[ShardKey Concurrency load balancer] cache-miss rejected: least-utilized backend %s ratio %.2f exceeds headroom %.2f, shardKeys: %v", n, ratio, l.cacheMissMaxUtilization, shardKeyList))
+				return nil, ErrCacheMissHeadroom
+			}
 			slog.InfoContext(req.Context(),
 				fmt.Sprintf("[ShardKey Concurrency load balancer] no prioritized backend available (exhausted %d), fallback to concurrency-based selection: %s, shardKeys: %v, candidates: %v", len(prioritized), n, shardKeyList, candidates),
 				slog.String("backend_name", n),
@@ -327,6 +412,7 @@ func (l *ShardKeyConcurrency) Process(req *octollm.Request) (*octollm.Response, 
 			return resp, err
 		}
 		excludeNames[n] = true
+		lastResp, lastErr = resp, err
 		retryCount++
 		if req.Context().Err() != nil {
 			slog.WarnContext(req.Context(), fmt.Sprintf("[ShardKey Concurrency load balancer] request context error: %v", req.Context().Err()))

--- a/pkg/engines/load-balancer/shard_key_concurrency.go
+++ b/pkg/engines/load-balancer/shard_key_concurrency.go
@@ -31,14 +31,25 @@ type concurrencyBackend struct {
 	// maxConcurrencyFn supplies the ratio denominator per request. It is always set by construction:
 	// dynamic backends use BackendItem.MaxConcurrencyFn, static backends use a closure over Weight.
 	maxConcurrencyFn ShardMaxConcurrencyFn
+	// cacheMissMaxUtilization is the per-backend headroom ceiling; see BackendItem.CacheMissMaxUtilization.
+	cacheMissMaxUtilization float64
 }
 
-// prioritizedBackend pairs a shard-key-resolved backend with whether it was resolved from one of the
-// top two (highest-priority) shard keys. strongCacheHit backends are high-confidence cache hits and
-// bypass the headroom ceiling; non-strongCacheHit backends are subject to cacheMissMaxUtilization.
+// prioritizedBackend pairs a shard-key-resolved backend with the shard-key list length and the index
+// of the shard key it was resolved from. isStrongCacheHit derives whether it is a high-confidence
+// cache hit (resolved from a top-priority shard key), which bypasses the headroom ceiling; weaker
+// hits are subject to the backend's cacheMissMaxUtilization.
 type prioritizedBackend struct {
-	backend        *concurrencyBackend
-	strongCacheHit bool
+	backend          *concurrencyBackend
+	shardKeyLen      int
+	cacheHitKeyIndex int
+}
+
+// isStrongCacheHit reports whether this is a strong (high-confidence) cache hit: one resolved from
+// either of the top two (highest-priority) shard keys. The "top two" threshold is fixed and not yet
+// configurable.
+func (pb *prioritizedBackend) isStrongCacheHit() bool {
+	return pb.cacheHitKeyIndex >= pb.shardKeyLen-2
 }
 
 // ShardKeyConcurrency implements a load balancer that:
@@ -60,12 +71,6 @@ type ShardKeyConcurrency struct {
 
 	retryTimeout  time.Duration
 	retryMaxCount int
-
-	// cacheMissMaxUtilization is the concurrency utilization (count/maxConcurrency) ceiling above
-	// which non-strong-cache-hit requests are denied headroom. Requests resolved from one of the last
-	// two shard keys are strong cache hits and bypass this ceiling; everything else (weak cache hits
-	// and full misses) is subject to it. A value >= 1.0 (or <= 0) disables the headroom reservation.
-	cacheMissMaxUtilization float64
 }
 
 var _ octollm.Engine = (*ShardKeyConcurrency)(nil)
@@ -83,7 +88,8 @@ var _ octollm.Engine = (*ShardKeyConcurrency)(nil)
 //   - redisClient: Redis client for shard-key ZSETs and concurrency ZCard
 //   - keyPrefix: prefix prepended to all Redis keys
 //   - concurrencyKeyFn: required; returns the Redis key used to track per-backend concurrency
-//   - cacheMissMaxUtilization: utilization ceiling for cache-miss requests; >= 1.0 disables headroom
+//
+// The cache-miss headroom ceiling is configured per backend via BackendItem.CacheMissMaxUtilization.
 func NewShardKeyConcurrency(
 	backends []BackendItem,
 	retryTimeout time.Duration,
@@ -93,7 +99,6 @@ func NewShardKeyConcurrency(
 	redisClient *redis.Client,
 	keyPrefix string,
 	concurrencyKeyFn func(req *octollm.Request, backendName string) string,
-	cacheMissMaxUtilization float64,
 ) (*ShardKeyConcurrency, error) {
 	if redisClient == nil {
 		return nil, fmt.Errorf("redisClient must be provided")
@@ -113,9 +118,10 @@ func NewShardKeyConcurrency(
 		}
 
 		cb = append(cb, &concurrencyBackend{
-			name:             b.Name,
-			engine:           b.Engine,
-			maxConcurrencyFn: maxConcurrencyFn,
+			name:                    b.Name,
+			engine:                  b.Engine,
+			maxConcurrencyFn:        maxConcurrencyFn,
+			cacheMissMaxUtilization: b.CacheMissMaxUtilization,
 		})
 	}
 
@@ -127,15 +133,14 @@ func NewShardKeyConcurrency(
 	}
 
 	return &ShardKeyConcurrency{
-		backends:                cb,
-		shardKeyListGetter:      shardKeyListGetter,
-		redisClient:             redisClient,
-		shardKeyTTL:             shardKeyTTL,
-		keyPrefix:               keyPrefix,
-		concurrencyKeyFn:        concurrencyKeyFn,
-		retryTimeout:            retryTimeout,
-		retryMaxCount:           retryMaxCount,
-		cacheMissMaxUtilization: cacheMissMaxUtilization,
+		backends:           cb,
+		shardKeyListGetter: shardKeyListGetter,
+		redisClient:        redisClient,
+		shardKeyTTL:        shardKeyTTL,
+		keyPrefix:          keyPrefix,
+		concurrencyKeyFn:   concurrencyKeyFn,
+		retryTimeout:       retryTimeout,
+		retryMaxCount:      retryMaxCount,
 	}, nil
 }
 
@@ -195,14 +200,16 @@ func (l *ShardKeyConcurrency) resolvePrioritizedBackends(
 				trimPipe.ZRemRangeByRank(ctx, l.redisKey(shardKeyList[i]), 0, stop)
 			}
 		}
-		// Hits on either of the top two (highest-priority) shard keys count as strong cache hits.
-		strongCacheHit := i >= len(shardKeyList)-2
 		for _, name := range backendNames {
 			if name == "" || seen[name] {
 				continue
 			}
 			if b, ok := backendByName[name]; ok {
-				prioritized = append(prioritized, prioritizedBackend{backend: b, strongCacheHit: strongCacheHit})
+				prioritized = append(prioritized, prioritizedBackend{
+					backend:          b,
+					shardKeyLen:      len(shardKeyList),
+					cacheHitKeyIndex: i,
+				})
 				seen[name] = true
 			}
 		}
@@ -219,7 +226,7 @@ func (l *ShardKeyConcurrency) resolvePrioritizedBackends(
 // using Redis ZCard. Backends in excludeNames are skipped. The returned float is the selected
 // backend's utilization ratio (count/maxConcurrency); it is 0 on the random fallback path below.
 // Falls back to uniform random selection among backends with positive effective capacity if Redis Exec fails.
-func (l *ShardKeyConcurrency) selectByConcurrency(req *octollm.Request, excludeNames map[string]bool) (string, octollm.Engine, float64) {
+func (l *ShardKeyConcurrency) selectByConcurrency(req *octollm.Request, excludeNames map[string]bool) (*concurrencyBackend, float64) {
 	ctx := req.Context()
 	candidates := make([]*concurrencyBackend, 0, len(l.backends))
 	for _, b := range l.backends {
@@ -229,7 +236,7 @@ func (l *ShardKeyConcurrency) selectByConcurrency(req *octollm.Request, excludeN
 		candidates = append(candidates, b)
 	}
 	if len(candidates) == 0 {
-		return "", nil, 0
+		return nil, 0
 	}
 	rand.Shuffle(len(candidates), func(i, j int) { candidates[i], candidates[j] = candidates[j], candidates[i] })
 
@@ -247,10 +254,9 @@ func (l *ShardKeyConcurrency) selectByConcurrency(req *octollm.Request, excludeN
 			}
 		}
 		if len(usable) == 0 {
-			return "", nil, 0
+			return nil, 0
 		}
-		b := usable[rand.Intn(len(usable))]
-		return b.name, b.engine, 0
+		return usable[0], 0
 	}
 
 	minRatio := math.MaxFloat64
@@ -271,20 +277,20 @@ func (l *ShardKeyConcurrency) selectByConcurrency(req *octollm.Request, excludeN
 		}
 	}
 	if selected == nil {
-		return "", nil, 0
+		return nil, 0
 	}
-	return selected.name, selected.engine, minRatio
+	return selected, minRatio
 }
 
-// headroomEnabled reports whether cache-miss headroom reservation is active. A configured
-// utilization of <=0 or >=1.0 disables it (no headroom is reserved).
-func (l *ShardKeyConcurrency) headroomEnabled() bool {
-	return l.cacheMissMaxUtilization > 0 && l.cacheMissMaxUtilization < 1.0
+// headroomEnabled reports whether cache-miss headroom reservation is active for this backend. A
+// configured utilization of <=0 or >=1.0 disables it (no headroom is reserved).
+func (b *concurrencyBackend) headroomEnabled() bool {
+	return b.cacheMissMaxUtilization > 0 && b.cacheMissMaxUtilization < 1.0
 }
 
 // overHeadroom reports whether the backend's current concurrency utilization (count/maxConcurrency)
-// exceeds cacheMissMaxUtilization. It fails open: a Redis error returns false so requests are not
-// blocked by a transient failure. Callers must guard with headroomEnabled.
+// exceeds its cacheMissMaxUtilization. It fails open: a Redis error returns false so requests are not
+// blocked by a transient failure. Callers must guard with b.headroomEnabled.
 func (l *ShardKeyConcurrency) overHeadroom(req *octollm.Request, b *concurrencyBackend) bool {
 	denom := b.maxConcurrencyFn(req)
 	if denom <= 0 {
@@ -295,7 +301,7 @@ func (l *ShardKeyConcurrency) overHeadroom(req *octollm.Request, b *concurrencyB
 		slog.WarnContext(req.Context(), fmt.Sprintf("[ShardKey Concurrency load balancer] failed to ZCard concurrency for headroom check on %s: %v", b.name, err))
 		return false
 	}
-	return float64(count)/float64(denom) > l.cacheMissMaxUtilization
+	return float64(count)/float64(denom) > b.cacheMissMaxUtilization
 }
 
 func (l *ShardKeyConcurrency) Process(req *octollm.Request) (*octollm.Response, error) {
@@ -332,10 +338,12 @@ func (l *ShardKeyConcurrency) Process(req *octollm.Request) (*octollm.Response, 
 				continue
 			}
 			// Weak cache hits (not top-two-shard-key) prioritized backends only get headroom up to
-			// cacheMissMaxUtilization; skip them once over so the reserved capacity stays for strong cache hits.
-			if !pb.strongCacheHit && l.headroomEnabled() && l.overHeadroom(req, b) {
+			// the backend's cacheMissMaxUtilization; skip them once over so the reserved capacity stays
+			// for strong cache hits.
+			strongCacheHit := pb.isStrongCacheHit()
+			if !strongCacheHit && b.headroomEnabled() && l.overHeadroom(req, b) {
 				slog.InfoContext(req.Context(),
-					fmt.Sprintf("[ShardKey Concurrency load balancer] skip weak-cache-hit prioritized backend over headroom %.2f: %s (index %d/%d), shardKeys: %v", l.cacheMissMaxUtilization, b.name, prioritizedIndex, len(prioritized), shardKeyList),
+					fmt.Sprintf("[ShardKey Concurrency load balancer] skip weak-cache-hit prioritized backend over headroom %.2f: %s (index %d/%d), shardKeys: %v", b.cacheMissMaxUtilization, b.name, prioritizedIndex, len(prioritized), shardKeyList),
 					slog.String("backend_name", b.name),
 				)
 				excludeNames[b.name] = true
@@ -345,7 +353,7 @@ func (l *ShardKeyConcurrency) Process(req *octollm.Request) (*octollm.Response, 
 				// concurrency selection. On a failover, surface the previous error rather than masking it.
 				if len(excludeNames) >= len(l.backends) {
 					if retryCount > 0 {
-						slog.WarnContext(req.Context(), fmt.Sprintf("[ShardKey Concurrency load balancer] all backends over headroom %.2f on failover, returning previous error: %v", l.cacheMissMaxUtilization, lastErr))
+						slog.WarnContext(req.Context(), fmt.Sprintf("[ShardKey Concurrency load balancer] all backends over headroom on failover, returning previous error: %v", lastErr))
 						return lastResp, lastErr
 					} else {
 						return nil, ErrCacheMissHeadroom
@@ -355,7 +363,7 @@ func (l *ShardKeyConcurrency) Process(req *octollm.Request) (*octollm.Response, 
 			}
 			n, eng = b.name, b.engine
 			slog.InfoContext(req.Context(),
-				fmt.Sprintf("[ShardKey Concurrency load balancer] prioritized backend hit (strongCacheHit=%t): %s (index %d/%d), shardKeys: %v", pb.strongCacheHit, n, prioritizedIndex, len(prioritized), shardKeyList),
+				fmt.Sprintf("[ShardKey Concurrency load balancer] prioritized backend hit (strongCacheHit=%t): %s (index %d/%d), shardKeys: %v", strongCacheHit, n, prioritizedIndex, len(prioritized), shardKeyList),
 				slog.String("backend_name", n),
 			)
 		} else {
@@ -365,17 +373,26 @@ func (l *ShardKeyConcurrency) Process(req *octollm.Request) (*octollm.Response, 
 					candidates = append(candidates, b.name)
 				}
 			}
-			var ratio float64
-			n, eng, ratio = l.selectByConcurrency(req, excludeNames)
-			// Full cache miss: selectByConcurrency picks the least-utilized backend, so if even that
-			// one is over the headroom ceiling, every backend is — reject to preserve headroom (429).
-			if eng != nil && l.headroomEnabled() && ratio > l.cacheMissMaxUtilization {
-				if retryCount > 0 {
-					slog.WarnContext(req.Context(), fmt.Sprintf("[ShardKey Concurrency load balancer] cache-miss over headroom %.2f on failover, returning previous error: %v", l.cacheMissMaxUtilization, lastErr))
-					return lastResp, lastErr
+			selected, ratio := l.selectByConcurrency(req, excludeNames)
+			if selected != nil {
+				n, eng = selected.name, selected.engine
+			}
+			// Full cache miss: gate the least-utilized backend on its own headroom ceiling. Because
+			// ceilings are per-backend, the lowest-ratio backend being over its ceiling does not imply
+			// every backend is over its own (another could sit under a more generous ceiling), so exclude
+			// it and continue — the next iteration re-selects among the rest. Only once every backend is
+			// excluded is it a true headroom rejection (429); on a failover, surface the previous error.
+			if selected != nil && selected.headroomEnabled() && ratio > selected.cacheMissMaxUtilization {
+				excludeNames[selected.name] = true
+				if len(excludeNames) >= len(l.backends) {
+					if retryCount > 0 {
+						slog.WarnContext(req.Context(), fmt.Sprintf("[ShardKey Concurrency load balancer] all backends over headroom on failover, returning previous error: %v", lastErr))
+						return lastResp, lastErr
+					} else {
+						return nil, ErrCacheMissHeadroom
+					}
 				}
-				slog.WarnContext(req.Context(), fmt.Sprintf("[ShardKey Concurrency load balancer] cache-miss rejected: least-utilized backend %s ratio %.2f exceeds headroom %.2f, shardKeys: %v", n, ratio, l.cacheMissMaxUtilization, shardKeyList))
-				return nil, ErrCacheMissHeadroom
+				continue
 			}
 			slog.InfoContext(req.Context(),
 				fmt.Sprintf("[ShardKey Concurrency load balancer] no prioritized backend available (exhausted %d), fallback to concurrency-based selection: %s, shardKeys: %v, candidates: %v", len(prioritized), n, shardKeyList, candidates),
@@ -384,6 +401,15 @@ func (l *ShardKeyConcurrency) Process(req *octollm.Request) (*octollm.Response, 
 		}
 
 		if eng == nil {
+			// No selectable backend remains (e.g. the only non-excluded backends have a 0 denominator,
+			// so selectByConcurrency cannot pick them and the all-excluded guard below never fires).
+			// On a failover, surface the previous error rather than masking it with a generic one.
+			if retryCount > 0 {
+				slog.WarnContext(req.Context(), fmt.Sprintf("[ShardKey Concurrency load balancer] no backend engine available on failover, returning previous error: %v", lastErr))
+				return lastResp, lastErr
+			}
+			// On the first attempt this is typically because every candidate backend's maxConcurrencyFn
+			// returned 0 (no effective capacity), leaving nothing selectable.
 			return nil, fmt.Errorf("no backend engine available")
 		}
 		req.SetMetadataValue(backendName, n)

--- a/pkg/engines/load-balancer/shard_key_concurrency_test.go
+++ b/pkg/engines/load-balancer/shard_key_concurrency_test.go
@@ -99,6 +99,7 @@ func TestShardKeyConcurrency_No_ShardKey(t *testing.T) {
 			func(_ *octollm.Request, backendName string) string {
 				return "concurrency_rate:service:gpt-4:" + backendName + ":tier_0"
 			},
+			1.0,
 		)
 		require.NoError(t, err)
 
@@ -137,6 +138,7 @@ func TestShardKeyConcurrency_No_ShardKey(t *testing.T) {
 			func(_ *octollm.Request, backendName string) string {
 				return "concurrency_rate:service:gpt-4:" + backendName + ":tier_0"
 			},
+			1.0,
 		)
 		require.NoError(t, err)
 
@@ -146,6 +148,7 @@ func TestShardKeyConcurrency_No_ShardKey(t *testing.T) {
 			func(_ *octollm.Request, backendName string) string {
 				return "concurrency_rate:service:gpt-4:" + backendName + ":tier_0"
 			},
+			1.0,
 		)
 		require.NoError(t, err)
 
@@ -207,6 +210,7 @@ func TestShardKeyConcurrency_Failover(t *testing.T) {
 		func(req *octollm.Request, backendName string) string {
 			return "concurrency_rate:service:gpt-4:" + backendName + ":tier_0"
 		},
+		1.0,
 	)
 	require.NoError(t, err)
 
@@ -242,6 +246,7 @@ func TestShardKeyConcurrency_NotRetriableError(t *testing.T) {
 		func(req *octollm.Request, backendName string) string {
 			return "concurrency_rate:service:gpt-4:" + backendName + ":tier_0"
 		},
+		1.0,
 	)
 	require.NoError(t, err)
 
@@ -278,6 +283,7 @@ func TestShardKeyConcurrency_ShardKey(t *testing.T) {
 		func(req *octollm.Request, backendName string) string {
 			return "concurrency_rate:service:gpt-4:" + backendName + ":tier_0"
 		},
+		1.0,
 	)
 	require.NoError(t, err)
 
@@ -378,6 +384,7 @@ func TestShardKeyConcurrency_maxConcurrencyFn(t *testing.T) {
 			func(_ *octollm.Request, backendName string) string {
 				return "concurrency:" + backendName + ":tier_0"
 			},
+			1.0,
 		)
 		require.NoError(t, err)
 		req := testhelper.CreateTestRequest()
@@ -399,6 +406,7 @@ func TestShardKeyConcurrency_maxConcurrencyFn(t *testing.T) {
 			func(_ *octollm.Request, backendName string) string {
 				return "concurrency:" + backendName + ":tier_0"
 			},
+			1.0,
 		)
 		require.NoError(t, err)
 		req := testhelper.CreateTestRequest()
@@ -424,6 +432,7 @@ func TestShardKeyConcurrency_maxConcurrencyFn(t *testing.T) {
 			func(_ *octollm.Request, backendName string) string {
 				return "concurrency:" + backendName + ":tier_0"
 			},
+			1.0,
 		)
 		require.NoError(t, err)
 		_, err = lb.Process(testhelper.CreateTestRequest())
@@ -448,6 +457,7 @@ func TestShardKeyConcurrency_maxConcurrencyFn(t *testing.T) {
 			func(_ *octollm.Request, backendName string) string {
 				return "concurrency:" + backendName + ":tier_0"
 			},
+			1.0,
 		)
 		require.NoError(t, err)
 		req := testhelper.CreateTestRequest()
@@ -488,6 +498,7 @@ func TestShardKeyConcurrency_maxConcurrencyFn(t *testing.T) {
 			func(_ *octollm.Request, backendName string) string {
 				return "concurrency:" + backendName + ":tier_0"
 			},
+			1.0,
 		)
 		require.NoError(t, err)
 		req := testhelper.CreateTestRequest()
@@ -516,6 +527,7 @@ func TestShardKeyConcurrency_maxConcurrencyFn(t *testing.T) {
 			func(_ *octollm.Request, backendName string) string {
 				return "concurrency:" + backendName + ":tier_0"
 			},
+			1.0,
 		)
 		require.NoError(t, err)
 		req := testhelper.CreateTestRequest()
@@ -537,6 +549,7 @@ func TestShardKeyConcurrency_maxConcurrencyFn(t *testing.T) {
 			func(_ *octollm.Request, backendName string) string {
 				return "concurrency:" + backendName + ":tier_0"
 			},
+			1.0,
 		)
 		require.NoError(t, err)
 		_, err = lb.Process(testhelper.CreateTestRequest())
@@ -555,7 +568,247 @@ func TestShardKeyConcurrency_maxConcurrencyFn(t *testing.T) {
 			func(_ *octollm.Request, backendName string) string {
 				return "concurrency:" + backendName + ":tier_0"
 			},
+			1.0,
 		)
 		require.Error(t, err)
+	})
+}
+
+// seedConcurrency seeds the concurrency ZSET for a backend with n distinct members, so the load
+// balancer's ZCard reads back exactly n in-flight requests.
+func seedConcurrency(t *testing.T, rd *redis.Client, backendName string, n int) {
+	t.Helper()
+	if n <= 0 {
+		return
+	}
+	members := make([]redis.Z, n)
+	for i := range members {
+		members[i] = redis.Z{Score: float64(i), Member: fmt.Sprintf("m%d", i)}
+	}
+	require.NoError(t, rd.ZAdd(t.Context(), "concurrency:"+backendName+":tier_0", members...).Err())
+}
+
+func TestShardKeyConcurrency_Headroom(t *testing.T) {
+	concurrencyKeyFn := func(_ *octollm.Request, backendName string) string {
+		return "concurrency:" + backendName + ":tier_0"
+	}
+	okEngine := octollm.EngineFunc(func(_ *octollm.Request) (*octollm.Response, error) {
+		return &octollm.Response{StatusCode: 200}, nil
+	})
+	selectedBackend := func(t *testing.T, req *octollm.Request) string {
+		t.Helper()
+		mv, ok := req.GetMetadataValue(backendName)
+		require.True(t, ok)
+		name, ok := mv.(string)
+		require.True(t, ok)
+		return name
+	}
+
+	t.Run("cache hit on last-two shard key bypasses headroom ceiling", func(t *testing.T) {
+		mr := miniredis.RunT(t)
+		defer mr.Close()
+		rd := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+
+		items := []BackendItem{
+			{Name: "hot", Weight: 10, Engine: okEngine},
+			{Name: "cool", Weight: 10, Engine: okEngine},
+		}
+		// hot is fully utilized (10/10 = 1.0 > 0.9) but is resolved from the last shard key.
+		seedConcurrency(t, rd, "hot", 10)
+
+		const keyPrefix = "hr-a"
+		require.NoError(t, rd.ZAdd(t.Context(), keyPrefix+":sk2", redis.Z{Score: 1, Member: "hot"}).Err())
+
+		lb, err := NewShardKeyConcurrency(
+			items,
+			time.Second, 3, time.Minute,
+			func(_ *octollm.Request) []string { return []string{"sk0", "sk1", "sk2"} },
+			rd, keyPrefix, concurrencyKeyFn,
+			0.9,
+		)
+		require.NoError(t, err)
+
+		req := testhelper.CreateTestRequest()
+		resp, err := lb.Process(req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Equal(t, "hot", selectedBackend(t, req), "cache-hit backend should be used even over the ceiling")
+	})
+
+	t.Run("non-cache-hit prioritized backend over ceiling is skipped", func(t *testing.T) {
+		mr := miniredis.RunT(t)
+		defer mr.Close()
+		rd := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+
+		items := []BackendItem{
+			{Name: "hot", Weight: 10, Engine: okEngine},
+			{Name: "cool", Weight: 10, Engine: okEngine},
+		}
+		seedConcurrency(t, rd, "hot", 10) // 1.0 > 0.9
+		seedConcurrency(t, rd, "cool", 0) // 0.0 < 0.9
+
+		const keyPrefix = "hr-b"
+		// hot is resolved from sk0, the third-from-last shard key -> not a cache hit.
+		require.NoError(t, rd.ZAdd(t.Context(), keyPrefix+":sk0", redis.Z{Score: 1, Member: "hot"}).Err())
+
+		lb, err := NewShardKeyConcurrency(
+			items,
+			time.Second, 3, time.Minute,
+			func(_ *octollm.Request) []string { return []string{"sk0", "sk1", "sk2"} },
+			rd, keyPrefix, concurrencyKeyFn,
+			0.9,
+		)
+		require.NoError(t, err)
+
+		req := testhelper.CreateTestRequest()
+		resp, err := lb.Process(req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Equal(t, "cool", selectedBackend(t, req), "over-ceiling non-cache-hit backend should be skipped for the under-ceiling one")
+	})
+
+	t.Run("full miss with all backends over ceiling returns 429", func(t *testing.T) {
+		mr := miniredis.RunT(t)
+		defer mr.Close()
+		rd := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+
+		items := []BackendItem{
+			{Name: "a", Weight: 10, Engine: okEngine},
+			{Name: "b", Weight: 10, Engine: okEngine},
+		}
+		seedConcurrency(t, rd, "a", 10)
+		seedConcurrency(t, rd, "b", 10)
+
+		lb, err := NewShardKeyConcurrency(
+			items,
+			time.Second, 3, time.Minute, nil, rd, "hr-c", concurrencyKeyFn,
+			0.9,
+		)
+		require.NoError(t, err)
+
+		resp, err := lb.Process(testhelper.CreateTestRequest())
+		require.ErrorIs(t, err, ErrCacheMissHeadroom)
+		assert.Nil(t, resp)
+	})
+
+	t.Run("full miss under ceiling is allowed", func(t *testing.T) {
+		mr := miniredis.RunT(t)
+		defer mr.Close()
+		rd := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+
+		items := []BackendItem{
+			{Name: "a", Weight: 10, Engine: okEngine},
+			{Name: "b", Weight: 10, Engine: okEngine},
+		}
+		seedConcurrency(t, rd, "a", 5) // 0.5 < 0.9
+		seedConcurrency(t, rd, "b", 5)
+
+		lb, err := NewShardKeyConcurrency(
+			items,
+			time.Second, 3, time.Minute, nil, rd, "hr-d", concurrencyKeyFn,
+			0.9,
+		)
+		require.NoError(t, err)
+
+		resp, err := lb.Process(testhelper.CreateTestRequest())
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+	})
+
+	t.Run("disabled headroom (1.0) serves over-ceiling miss", func(t *testing.T) {
+		mr := miniredis.RunT(t)
+		defer mr.Close()
+		rd := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+
+		items := []BackendItem{
+			{Name: "a", Weight: 10, Engine: okEngine},
+			{Name: "b", Weight: 10, Engine: okEngine},
+		}
+		seedConcurrency(t, rd, "a", 10)
+		seedConcurrency(t, rd, "b", 10)
+
+		lb, err := NewShardKeyConcurrency(
+			items,
+			time.Second, 3, time.Minute, nil, rd, "hr-e", concurrencyKeyFn,
+			1.0,
+		)
+		require.NoError(t, err)
+
+		resp, err := lb.Process(testhelper.CreateTestRequest())
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+	})
+
+	// Both subtests below exercise the prioritized-loop exhaustion branch: skipping a weak cache hit
+	// over the ceiling excludes the last remaining backend.
+	t.Run("all weak cache hits over ceiling returns 429", func(t *testing.T) {
+		mr := miniredis.RunT(t)
+		defer mr.Close()
+		rd := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+
+		items := []BackendItem{
+			{Name: "a", Weight: 10, Engine: okEngine},
+			{Name: "b", Weight: 10, Engine: okEngine},
+		}
+		seedConcurrency(t, rd, "a", 10) // 1.0 > 0.9
+		seedConcurrency(t, rd, "b", 10)
+
+		const keyPrefix = "hr-f"
+		// Both backends are resolved only from sk0 (third-from-last) -> weak cache hits.
+		require.NoError(t, rd.ZAdd(t.Context(), keyPrefix+":sk0",
+			redis.Z{Score: 1, Member: "a"}, redis.Z{Score: 2, Member: "b"}).Err())
+
+		lb, err := NewShardKeyConcurrency(
+			items,
+			time.Second, 3, time.Minute,
+			func(_ *octollm.Request) []string { return []string{"sk0", "sk1", "sk2"} },
+			rd, keyPrefix, concurrencyKeyFn,
+			0.9,
+		)
+		require.NoError(t, err)
+
+		resp, err := lb.Process(testhelper.CreateTestRequest())
+		require.ErrorIs(t, err, ErrCacheMissHeadroom)
+		assert.Nil(t, resp)
+	})
+
+	t.Run("strong cache hit fails then weak hits over ceiling returns previous error", func(t *testing.T) {
+		mr := miniredis.RunT(t)
+		defer mr.Close()
+		rd := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+
+		upstreamErr := fmt.Errorf("upstream temporarily unavailable")
+		failEngine := octollm.EngineFunc(func(_ *octollm.Request) (*octollm.Response, error) {
+			return nil, upstreamErr
+		})
+
+		items := []BackendItem{
+			{Name: "strong", Weight: 10, Engine: failEngine},
+			{Name: "weak1", Weight: 10, Engine: okEngine},
+			{Name: "weak2", Weight: 10, Engine: okEngine},
+		}
+		// strong bypasses the ceiling (last shard key) but its engine fails; the two weak hits are
+		// over the ceiling and get skipped, exhausting all backends on a failover.
+		seedConcurrency(t, rd, "weak1", 10) // 1.0 > 0.9
+		seedConcurrency(t, rd, "weak2", 10)
+
+		const keyPrefix = "hr-g"
+		require.NoError(t, rd.ZAdd(t.Context(), keyPrefix+":sk2", redis.Z{Score: 1, Member: "strong"}).Err())
+		require.NoError(t, rd.ZAdd(t.Context(), keyPrefix+":sk0",
+			redis.Z{Score: 1, Member: "weak1"}, redis.Z{Score: 2, Member: "weak2"}).Err())
+
+		lb, err := NewShardKeyConcurrency(
+			items,
+			time.Second, 3, time.Minute,
+			func(_ *octollm.Request) []string { return []string{"sk0", "sk1", "sk2"} },
+			rd, keyPrefix, concurrencyKeyFn,
+			0.9,
+		)
+		require.NoError(t, err)
+
+		resp, err := lb.Process(testhelper.CreateTestRequest())
+		require.ErrorIs(t, err, upstreamErr, "failover should surface the upstream error, not the headroom sentinel")
+		require.NotErrorIs(t, err, ErrCacheMissHeadroom)
+		assert.Nil(t, resp)
 	})
 }

--- a/pkg/engines/load-balancer/shard_key_concurrency_test.go
+++ b/pkg/engines/load-balancer/shard_key_concurrency_test.go
@@ -99,7 +99,6 @@ func TestShardKeyConcurrency_No_ShardKey(t *testing.T) {
 			func(_ *octollm.Request, backendName string) string {
 				return "concurrency_rate:service:gpt-4:" + backendName + ":tier_0"
 			},
-			1.0,
 		)
 		require.NoError(t, err)
 
@@ -138,7 +137,6 @@ func TestShardKeyConcurrency_No_ShardKey(t *testing.T) {
 			func(_ *octollm.Request, backendName string) string {
 				return "concurrency_rate:service:gpt-4:" + backendName + ":tier_0"
 			},
-			1.0,
 		)
 		require.NoError(t, err)
 
@@ -148,7 +146,6 @@ func TestShardKeyConcurrency_No_ShardKey(t *testing.T) {
 			func(_ *octollm.Request, backendName string) string {
 				return "concurrency_rate:service:gpt-4:" + backendName + ":tier_0"
 			},
-			1.0,
 		)
 		require.NoError(t, err)
 
@@ -210,7 +207,6 @@ func TestShardKeyConcurrency_Failover(t *testing.T) {
 		func(req *octollm.Request, backendName string) string {
 			return "concurrency_rate:service:gpt-4:" + backendName + ":tier_0"
 		},
-		1.0,
 	)
 	require.NoError(t, err)
 
@@ -246,7 +242,6 @@ func TestShardKeyConcurrency_NotRetriableError(t *testing.T) {
 		func(req *octollm.Request, backendName string) string {
 			return "concurrency_rate:service:gpt-4:" + backendName + ":tier_0"
 		},
-		1.0,
 	)
 	require.NoError(t, err)
 
@@ -283,7 +278,6 @@ func TestShardKeyConcurrency_ShardKey(t *testing.T) {
 		func(req *octollm.Request, backendName string) string {
 			return "concurrency_rate:service:gpt-4:" + backendName + ":tier_0"
 		},
-		1.0,
 	)
 	require.NoError(t, err)
 
@@ -384,7 +378,6 @@ func TestShardKeyConcurrency_maxConcurrencyFn(t *testing.T) {
 			func(_ *octollm.Request, backendName string) string {
 				return "concurrency:" + backendName + ":tier_0"
 			},
-			1.0,
 		)
 		require.NoError(t, err)
 		req := testhelper.CreateTestRequest()
@@ -406,7 +399,6 @@ func TestShardKeyConcurrency_maxConcurrencyFn(t *testing.T) {
 			func(_ *octollm.Request, backendName string) string {
 				return "concurrency:" + backendName + ":tier_0"
 			},
-			1.0,
 		)
 		require.NoError(t, err)
 		req := testhelper.CreateTestRequest()
@@ -432,7 +424,6 @@ func TestShardKeyConcurrency_maxConcurrencyFn(t *testing.T) {
 			func(_ *octollm.Request, backendName string) string {
 				return "concurrency:" + backendName + ":tier_0"
 			},
-			1.0,
 		)
 		require.NoError(t, err)
 		_, err = lb.Process(testhelper.CreateTestRequest())
@@ -457,7 +448,6 @@ func TestShardKeyConcurrency_maxConcurrencyFn(t *testing.T) {
 			func(_ *octollm.Request, backendName string) string {
 				return "concurrency:" + backendName + ":tier_0"
 			},
-			1.0,
 		)
 		require.NoError(t, err)
 		req := testhelper.CreateTestRequest()
@@ -498,7 +488,6 @@ func TestShardKeyConcurrency_maxConcurrencyFn(t *testing.T) {
 			func(_ *octollm.Request, backendName string) string {
 				return "concurrency:" + backendName + ":tier_0"
 			},
-			1.0,
 		)
 		require.NoError(t, err)
 		req := testhelper.CreateTestRequest()
@@ -527,7 +516,6 @@ func TestShardKeyConcurrency_maxConcurrencyFn(t *testing.T) {
 			func(_ *octollm.Request, backendName string) string {
 				return "concurrency:" + backendName + ":tier_0"
 			},
-			1.0,
 		)
 		require.NoError(t, err)
 		req := testhelper.CreateTestRequest()
@@ -549,7 +537,6 @@ func TestShardKeyConcurrency_maxConcurrencyFn(t *testing.T) {
 			func(_ *octollm.Request, backendName string) string {
 				return "concurrency:" + backendName + ":tier_0"
 			},
-			1.0,
 		)
 		require.NoError(t, err)
 		_, err = lb.Process(testhelper.CreateTestRequest())
@@ -568,7 +555,6 @@ func TestShardKeyConcurrency_maxConcurrencyFn(t *testing.T) {
 			func(_ *octollm.Request, backendName string) string {
 				return "concurrency:" + backendName + ":tier_0"
 			},
-			1.0,
 		)
 		require.Error(t, err)
 	})
@@ -610,8 +596,8 @@ func TestShardKeyConcurrency_Headroom(t *testing.T) {
 		rd := redis.NewClient(&redis.Options{Addr: mr.Addr()})
 
 		items := []BackendItem{
-			{Name: "hot", Weight: 10, Engine: okEngine},
-			{Name: "cool", Weight: 10, Engine: okEngine},
+			{Name: "hot", Weight: 10, Engine: okEngine, CacheMissMaxUtilization: 0.9},
+			{Name: "cool", Weight: 10, Engine: okEngine, CacheMissMaxUtilization: 0.9},
 		}
 		// hot is fully utilized (10/10 = 1.0 > 0.9) but is resolved from the last shard key.
 		seedConcurrency(t, rd, "hot", 10)
@@ -624,7 +610,6 @@ func TestShardKeyConcurrency_Headroom(t *testing.T) {
 			time.Second, 3, time.Minute,
 			func(_ *octollm.Request) []string { return []string{"sk0", "sk1", "sk2"} },
 			rd, keyPrefix, concurrencyKeyFn,
-			0.9,
 		)
 		require.NoError(t, err)
 
@@ -641,8 +626,8 @@ func TestShardKeyConcurrency_Headroom(t *testing.T) {
 		rd := redis.NewClient(&redis.Options{Addr: mr.Addr()})
 
 		items := []BackendItem{
-			{Name: "hot", Weight: 10, Engine: okEngine},
-			{Name: "cool", Weight: 10, Engine: okEngine},
+			{Name: "hot", Weight: 10, Engine: okEngine, CacheMissMaxUtilization: 0.9},
+			{Name: "cool", Weight: 10, Engine: okEngine, CacheMissMaxUtilization: 0.9},
 		}
 		seedConcurrency(t, rd, "hot", 10) // 1.0 > 0.9
 		seedConcurrency(t, rd, "cool", 0) // 0.0 < 0.9
@@ -656,7 +641,6 @@ func TestShardKeyConcurrency_Headroom(t *testing.T) {
 			time.Second, 3, time.Minute,
 			func(_ *octollm.Request) []string { return []string{"sk0", "sk1", "sk2"} },
 			rd, keyPrefix, concurrencyKeyFn,
-			0.9,
 		)
 		require.NoError(t, err)
 
@@ -673,8 +657,8 @@ func TestShardKeyConcurrency_Headroom(t *testing.T) {
 		rd := redis.NewClient(&redis.Options{Addr: mr.Addr()})
 
 		items := []BackendItem{
-			{Name: "a", Weight: 10, Engine: okEngine},
-			{Name: "b", Weight: 10, Engine: okEngine},
+			{Name: "a", Weight: 10, Engine: okEngine, CacheMissMaxUtilization: 0.9},
+			{Name: "b", Weight: 10, Engine: okEngine, CacheMissMaxUtilization: 0.9},
 		}
 		seedConcurrency(t, rd, "a", 10)
 		seedConcurrency(t, rd, "b", 10)
@@ -682,7 +666,6 @@ func TestShardKeyConcurrency_Headroom(t *testing.T) {
 		lb, err := NewShardKeyConcurrency(
 			items,
 			time.Second, 3, time.Minute, nil, rd, "hr-c", concurrencyKeyFn,
-			0.9,
 		)
 		require.NoError(t, err)
 
@@ -697,8 +680,8 @@ func TestShardKeyConcurrency_Headroom(t *testing.T) {
 		rd := redis.NewClient(&redis.Options{Addr: mr.Addr()})
 
 		items := []BackendItem{
-			{Name: "a", Weight: 10, Engine: okEngine},
-			{Name: "b", Weight: 10, Engine: okEngine},
+			{Name: "a", Weight: 10, Engine: okEngine, CacheMissMaxUtilization: 0.9},
+			{Name: "b", Weight: 10, Engine: okEngine, CacheMissMaxUtilization: 0.9},
 		}
 		seedConcurrency(t, rd, "a", 5) // 0.5 < 0.9
 		seedConcurrency(t, rd, "b", 5)
@@ -706,13 +689,40 @@ func TestShardKeyConcurrency_Headroom(t *testing.T) {
 		lb, err := NewShardKeyConcurrency(
 			items,
 			time.Second, 3, time.Minute, nil, rd, "hr-d", concurrencyKeyFn,
-			0.9,
 		)
 		require.NoError(t, err)
 
 		resp, err := lb.Process(testhelper.CreateTestRequest())
 		require.NoError(t, err)
 		require.NotNil(t, resp)
+	})
+
+	t.Run("full miss skips lowest-ratio backend over its own ceiling for one under a higher ceiling", func(t *testing.T) {
+		mr := miniredis.RunT(t)
+		defer mr.Close()
+		rd := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+
+		// Per-backend ceilings: the least-utilized backend "a" (0.6) is over its own 0.5 ceiling, while
+		// the more-utilized "b" (0.8) is under its more generous 0.9 ceiling. selectByConcurrency picks
+		// "a" first by min ratio; the cache-miss path must exclude it and re-select "b" rather than 429.
+		items := []BackendItem{
+			{Name: "a", Weight: 10, Engine: okEngine, CacheMissMaxUtilization: 0.5},
+			{Name: "b", Weight: 10, Engine: okEngine, CacheMissMaxUtilization: 0.9},
+		}
+		seedConcurrency(t, rd, "a", 6) // 0.6 > 0.5 (over its ceiling)
+		seedConcurrency(t, rd, "b", 8) // 0.8 < 0.9 (under its ceiling)
+
+		lb, err := NewShardKeyConcurrency(
+			items,
+			time.Second, 3, time.Minute, nil, rd, "hr-d2", concurrencyKeyFn,
+		)
+		require.NoError(t, err)
+
+		req := testhelper.CreateTestRequest()
+		resp, err := lb.Process(req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Equal(t, "b", selectedBackend(t, req), "lowest-ratio backend over its own ceiling should be skipped for the one under a higher ceiling")
 	})
 
 	t.Run("disabled headroom (1.0) serves over-ceiling miss", func(t *testing.T) {
@@ -730,7 +740,6 @@ func TestShardKeyConcurrency_Headroom(t *testing.T) {
 		lb, err := NewShardKeyConcurrency(
 			items,
 			time.Second, 3, time.Minute, nil, rd, "hr-e", concurrencyKeyFn,
-			1.0,
 		)
 		require.NoError(t, err)
 
@@ -747,8 +756,8 @@ func TestShardKeyConcurrency_Headroom(t *testing.T) {
 		rd := redis.NewClient(&redis.Options{Addr: mr.Addr()})
 
 		items := []BackendItem{
-			{Name: "a", Weight: 10, Engine: okEngine},
-			{Name: "b", Weight: 10, Engine: okEngine},
+			{Name: "a", Weight: 10, Engine: okEngine, CacheMissMaxUtilization: 0.9},
+			{Name: "b", Weight: 10, Engine: okEngine, CacheMissMaxUtilization: 0.9},
 		}
 		seedConcurrency(t, rd, "a", 10) // 1.0 > 0.9
 		seedConcurrency(t, rd, "b", 10)
@@ -763,7 +772,6 @@ func TestShardKeyConcurrency_Headroom(t *testing.T) {
 			time.Second, 3, time.Minute,
 			func(_ *octollm.Request) []string { return []string{"sk0", "sk1", "sk2"} },
 			rd, keyPrefix, concurrencyKeyFn,
-			0.9,
 		)
 		require.NoError(t, err)
 
@@ -783,9 +791,9 @@ func TestShardKeyConcurrency_Headroom(t *testing.T) {
 		})
 
 		items := []BackendItem{
-			{Name: "strong", Weight: 10, Engine: failEngine},
-			{Name: "weak1", Weight: 10, Engine: okEngine},
-			{Name: "weak2", Weight: 10, Engine: okEngine},
+			{Name: "strong", Weight: 10, Engine: failEngine, CacheMissMaxUtilization: 0.9},
+			{Name: "weak1", Weight: 10, Engine: okEngine, CacheMissMaxUtilization: 0.9},
+			{Name: "weak2", Weight: 10, Engine: okEngine, CacheMissMaxUtilization: 0.9},
 		}
 		// strong bypasses the ceiling (last shard key) but its engine fails; the two weak hits are
 		// over the ceiling and get skipped, exhausting all backends on a failover.
@@ -802,7 +810,6 @@ func TestShardKeyConcurrency_Headroom(t *testing.T) {
 			time.Second, 3, time.Minute,
 			func(_ *octollm.Request) []string { return []string{"sk0", "sk1", "sk2"} },
 			rd, keyPrefix, concurrencyKeyFn,
-			0.9,
 		)
 		require.NoError(t, err)
 


### PR DESCRIPTION
* Add cacheMissMaxUtilization ceiling to NewShardKeyConcurrency: backends resolved from one of the last two shard keys are strong cache hits and bypass the ceiling; weak cache hits and full misses are denied headroom once utilization exceeds it
* Skip over-ceiling weak-cache-hit prioritized backends, and reject full misses with ErrCacheMissHeadroom when every backend is over the ceiling
* Preserve the prior upstream error instead of the headroom sentinel on failover
* A value >= 1.0 (or <= 0) disables the reservation, keeping legacy behavior
* Cover the feature with TestShardKeyConcurrency_Headroom subtests