### PR TITLE
feat(streammerge,engines): non-stream to stream engine

### DIFF
--- a/pkg/composer/rule_composer.go
+++ b/pkg/composer/rule_composer.go
@@ -258,35 +258,6 @@ type RuleComposerEngine struct {
 	OrgName string
 }
 
-func checkIsStream(req *octollm.Request) (bool, error) {
-	if action, ok := octollm.GetCtxValue[string](req, octollm.ContextKeyAction); ok {
-		return octollm.IsStreamAction(action), nil
-	}
-
-	parsed, err := req.Body.Parsed()
-	if err != nil {
-		return false, err
-	}
-
-	switch body := parsed.(type) {
-	case *openai.ChatCompletionRequest:
-		if body.Stream != nil && *body.Stream {
-			return true, nil
-		}
-	case *openai.CompletionRequest:
-		return body.Stream, nil
-	case *openai.ResponsesRequest:
-		if body.Stream != nil && *body.Stream {
-			return true, nil
-		}
-	case *anthropic.ClaudeMessagesRequest:
-		if body.Stream != nil && *body.Stream {
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
 var _ octollm.Engine = (*RuleComposerEngine)(nil)
 
 func (r *RuleComposerEngine) Process(req *octollm.Request) (*octollm.Response, error) {
@@ -325,7 +296,7 @@ func (r *RuleComposerEngine) Process(req *octollm.Request) (*octollm.Response, e
 	}
 
 	if signalIsStream, ok := octollm.GetCtxValue[func(bool)](req, octollm.ContextKeyStreamSignaler); ok && signalIsStream != nil {
-		isStream, err := checkIsStream(req)
+		isStream, err := octollm.IsStreamRequest(req)
 		if err != nil {
 			return nil, fmt.Errorf("failed to check if request is stream: %w", err)
 		}

--- a/pkg/composer/rule_composer.go
+++ b/pkg/composer/rule_composer.go
@@ -296,7 +296,9 @@ func (r *RuleComposerEngine) Process(req *octollm.Request) (*octollm.Response, e
 	}
 
 	if signalIsStream, ok := octollm.GetCtxValue[func(bool)](req, octollm.ContextKeyStreamSignaler); ok && signalIsStream != nil {
-		isStream, err := octollm.IsStreamRequest(req)
+		// IsStream caches the classification into req's context, so downstream
+		// engines see it without re-parsing the body.
+		isStream, err := req.IsStream()
 		if err != nil {
 			return nil, fmt.Errorf("failed to check if request is stream: %w", err)
 		}
@@ -304,8 +306,6 @@ func (r *RuleComposerEngine) Process(req *octollm.Request) (*octollm.Response, e
 		if isStream {
 			slog.InfoContext(req.Context(), "[RuleComposerEngine] Detected stream request")
 		}
-		ctx := context.WithValue(req.Context(), octollm.ContextKeyIsStream, isStream)
-		req = req.WithContext(ctx)
 	}
 
 	engine, err := r.getEngine(r.OrgName, r.Model)

--- a/pkg/engines/client/general.go
+++ b/pkg/engines/client/general.go
@@ -44,7 +44,7 @@ type GeneralEndpointConfig struct {
 var DefaultURLPathChatCompletions = "/v1/chat/completions"
 var DefaultURLPathCompletions = "/v1/completions"
 var DefaultURLPathClaudeMessages = "/v1/messages"
-var DefaultURLPathVertex = "v1/models/{modelNameWithAction}" // Path for Vertex AI, {modelNameWithAction} includes action (e.g., "gemini-2.0-flash:generateContent")
+var DefaultURLPathVertex = "/v1beta/models/{modelNameWithAction}" // Path for Vertex AI, {modelNameWithAction} includes action (e.g., "gemini-2.0-flash:generateContent")
 var DefaultURLPathEmbeddings = "/v1/embeddings"
 var DefaultURLPathRerank = "/v1/rerank"
 var DefaultURLPathResponses = "/v1/responses"

--- a/pkg/engines/non_stream_to_stream.go
+++ b/pkg/engines/non_stream_to_stream.go
@@ -21,11 +21,13 @@ import (
 // to restrict it to an allowlist; any other format then passes straight through.
 //
 // Placement matters: it must wrap (sit outside) the request-rewrite engine so
-// the downstream rewrite sees a stream request. It marks the request as streaming
-// in a format-specific way (a body `stream` flag for most formats, or the
-// streamGenerateContent action + ?alt=sse for Gemini) and sets
-// octollm.ContextKeyIsStream in the context, which the rewrite engine keys off of
-// so stream-specific rewrites (e.g. stream_options.include_usage) are applied.
+// the downstream rewrite sees a stream request — stream-conditional rewrites
+// (e.g. stream_options.include_usage) match on the body's `stream` field. It
+// marks the request as streaming in a format-specific way (a body `stream` flag
+// for most formats, or the streamGenerateContent action + ?alt=sse for Gemini)
+// and overrides octollm.ContextKeyIsStream on the derived request's context so
+// downstream Request.IsStream calls report streaming despite the `false` this
+// engine's own check just cached.
 type NonStreamToStreamEngine struct {
 	Next octollm.Engine
 
@@ -84,7 +86,7 @@ func (e *NonStreamToStreamEngine) Process(req *octollm.Request) (*octollm.Respon
 	// Already streaming, or no merger for this format: pass through untouched.
 	// A body that cannot be parsed is treated as non-stream; the downstream
 	// engine will surface the real error.
-	if isStream, _ := octollm.IsStreamRequest(req); isStream {
+	if isStream, _ := req.IsStream(); isStream {
 		return e.Next.Process(req)
 	}
 	merger, err := streammerge.For(req.Format)
@@ -166,6 +168,8 @@ func bodyStreamRequest(req *octollm.Request) (*octollm.Request, error) {
 		return nil, fmt.Errorf("set stream flag: %w", err)
 	}
 
+	// Setting the key by hand is the streamness-change exception documented on
+	// Request.IsStream: it overrides the false this engine's check just cached.
 	ctx := context.WithValue(req.Context(), octollm.ContextKeyIsStream, true)
 	streamReq := req.WithContext(ctx)
 	// WithContext shallow-copies the Request, so it shares the Body pointer with

--- a/pkg/engines/non_stream_to_stream.go
+++ b/pkg/engines/non_stream_to_stream.go
@@ -1,0 +1,188 @@
+package engines
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/tidwall/sjson"
+
+	"github.com/infinigence/octollm/pkg/octollm"
+	"github.com/infinigence/octollm/pkg/streammerge"
+)
+
+// NonStreamToStreamEngine turns a non-stream request into a streaming one before
+// handing it to the next engine, then merges the streamed chunks back into a
+// single non-stream response for the client. It only applies to formats that
+// have a chunk merger (see streammerge.For); requests that are already streaming,
+// or whose format has no merger, pass through untouched.
+//
+// By default it applies to every format that has a merger. Use WithEnabledFormats
+// to restrict it to an allowlist; any other format then passes straight through.
+//
+// Placement matters: it must wrap (sit outside) the request-rewrite engine so
+// the downstream rewrite sees a stream request. It marks the request as streaming
+// in a format-specific way (a body `stream` flag for most formats, or the
+// streamGenerateContent action + ?alt=sse for Gemini) and sets
+// octollm.ContextKeyIsStream in the context, which the rewrite engine keys off of
+// so stream-specific rewrites (e.g. stream_options.include_usage) are applied.
+type NonStreamToStreamEngine struct {
+	Next octollm.Engine
+
+	// enabled is the allowlist of formats to force-stream. An empty set means
+	// "every format that has a merger".
+	enabled map[octollm.APIFormat]struct{}
+}
+
+// nonStreamToStreamConfig holds the settings options may set. Options operate on
+// this rather than the engine, so they cannot touch Next or the runtime state.
+type nonStreamToStreamConfig struct {
+	enabled map[octollm.APIFormat]struct{}
+}
+
+// NonStreamToStreamOption configures a NonStreamToStreamEngine.
+type NonStreamToStreamOption func(*nonStreamToStreamConfig)
+
+// WithEnabledFormats restricts force-streaming to the given API formats. Without
+// it, the default is to force-stream every format that has a merger.
+func WithEnabledFormats(formats ...octollm.APIFormat) NonStreamToStreamOption {
+	return func(c *nonStreamToStreamConfig) {
+		c.enabled = make(map[octollm.APIFormat]struct{}, len(formats))
+		for _, f := range formats {
+			c.enabled[f] = struct{}{}
+		}
+	}
+}
+
+var _ octollm.Engine = (*NonStreamToStreamEngine)(nil)
+
+// NewNonStreamToStreamEngine wraps next, applying any options over the default
+// behavior (force-stream every format that has a chunk merger).
+func NewNonStreamToStreamEngine(next octollm.Engine, opts ...NonStreamToStreamOption) *NonStreamToStreamEngine {
+	var cfg nonStreamToStreamConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return &NonStreamToStreamEngine{Next: next, enabled: cfg.enabled}
+}
+
+// enabledFor reports whether req's format should be force-streamed. An empty
+// allowlist enables every format (the merger check happens separately).
+func (e *NonStreamToStreamEngine) enabledFor(format octollm.APIFormat) bool {
+	if len(e.enabled) == 0 {
+		return true
+	}
+	_, ok := e.enabled[format]
+	return ok
+}
+
+func (e *NonStreamToStreamEngine) Process(req *octollm.Request) (*octollm.Response, error) {
+	// Outside the allowlist (when one is configured): pass through untouched.
+	if !e.enabledFor(req.Format) {
+		return e.Next.Process(req)
+	}
+	// Already streaming, or no merger for this format: pass through untouched.
+	// A body that cannot be parsed is treated as non-stream; the downstream
+	// engine will surface the real error.
+	if isStream, _ := octollm.IsStreamRequest(req); isStream {
+		return e.Next.Process(req)
+	}
+	merger, err := streammerge.For(req.Format)
+	if err != nil {
+		return e.Next.Process(req)
+	}
+
+	streamReq, err := toStreamRequest(req)
+	if err != nil {
+		return nil, fmt.Errorf("convert request to stream: %w", err)
+	}
+
+	resp, err := e.Next.Process(streamReq)
+	if err != nil {
+		return nil, err
+	}
+
+	// Upstream may still answer non-stream (e.g. an error short-circuit returned
+	// a plain body). Nothing to merge, pass it through as-is.
+	if resp.Stream == nil {
+		return resp, nil
+	}
+	defer resp.Stream.Close()
+
+	for chunk := range resp.Stream.Chan() {
+		if err := merger.Merge(chunk); err != nil {
+			return nil, fmt.Errorf("merge stream chunk: %w", err)
+		}
+	}
+	body, err := merger.Merged()
+	if err != nil {
+		return nil, fmt.Errorf("get merged response body: %w", err)
+	}
+
+	header := resp.Header.Clone()
+	if header == nil {
+		header = http.Header{}
+	}
+	header.Set("Content-Type", "application/json")
+	// The merged body is freshly serialized and uncompressed, so any framing
+	// headers carried over from the stream response no longer apply.
+	header.Del("Content-Length")
+	header.Del("Content-Encoding")
+	header.Del("Transfer-Encoding")
+	return octollm.NewNonStreamResponse(http.StatusOK, header, body), nil
+}
+
+// vertexStreamAction is the Gemini generateContent action's streaming variant.
+const vertexStreamAction = "streamGenerateContent"
+
+// toStreamRequest returns a copy of req that downstream engines and the upstream
+// client will treat as a streaming request, without mutating state shared with
+// the original request. How "streaming" is expressed is format-specific, so each
+// format is handled explicitly.
+func toStreamRequest(req *octollm.Request) (*octollm.Request, error) {
+	switch req.Format {
+	case octollm.APIFormatChatCompletions,
+		octollm.APIFormatCompletions,
+		octollm.APIFormatResponses,
+		octollm.APIFormatClaudeMessages:
+		return bodyStreamRequest(req)
+	case octollm.APIFormatGoogleGenerateContent:
+		return vertexStreamRequest(req)
+	default:
+		return nil, fmt.Errorf("force-stream not supported for format %q", req.Format)
+	}
+}
+
+// bodyStreamRequest flips the top-level `stream` flag in the JSON body and marks
+// the context as streaming. Used by formats that signal streaming via the body
+// (OpenAI chat/completions, completions, responses; Claude messages).
+func bodyStreamRequest(req *octollm.Request) (*octollm.Request, error) {
+	b, err := req.Body.Bytes()
+	if err != nil {
+		return nil, fmt.Errorf("read request body: %w", err)
+	}
+	b, err = sjson.SetBytes(b, "stream", true)
+	if err != nil {
+		return nil, fmt.Errorf("set stream flag: %w", err)
+	}
+
+	ctx := context.WithValue(req.Context(), octollm.ContextKeyIsStream, true)
+	streamReq := req.WithContext(ctx)
+	// WithContext shallow-copies the Request, so it shares the Body pointer with
+	// req. Give it an independent body so flipping `stream` does not leak into the
+	// original request still held by outer engines.
+	streamReq.Body = octollm.NewBodyFromBytes(b, req.Body.Parser())
+	return streamReq, nil
+}
+
+// vertexStreamRequest switches a Gemini generateContent request to its streaming
+// form. Vertex has no body `stream` flag: the client builds the upstream URL from
+// the action (streamGenerateContent) and appends ?alt=sse when ContextKeyIsSSE is
+// set, so this only touches the context and leaves the body untouched.
+func vertexStreamRequest(req *octollm.Request) (*octollm.Request, error) {
+	ctx := req.Context()
+	ctx = context.WithValue(ctx, octollm.ContextKeyIsStream, true)
+	ctx = context.WithValue(ctx, octollm.ContextKeyAction, vertexStreamAction)
+	ctx = context.WithValue(ctx, octollm.ContextKeyIsSSE, true)
+	return req.WithContext(ctx), nil
+}

--- a/pkg/engines/non_stream_to_stream_test.go
+++ b/pkg/engines/non_stream_to_stream_test.go
@@ -1,0 +1,177 @@
+package engines
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/tidwall/gjson"
+
+	"github.com/infinigence/octollm/pkg/octollm"
+	"github.com/infinigence/octollm/pkg/types/openai"
+)
+
+// streamFromChunks builds a stream response whose chunks are the given SSE data
+// payloads, parsed as ChatCompletionStreamChunk just like the real client does.
+func streamFromChunks(datas ...string) *octollm.Response {
+	ch := make(chan *octollm.StreamChunk, len(datas))
+	for _, d := range datas {
+		ch <- &octollm.StreamChunk{
+			Body: octollm.NewBodyFromBytes([]byte(d), &octollm.JSONParser[openai.ChatCompletionStreamChunk]{}),
+		}
+	}
+	close(ch)
+	return octollm.NewStreamResponse(200, http.Header{}, octollm.NewStreamChan(ch, func() {}))
+}
+
+func chatReq(ctx context.Context) *octollm.Request {
+	r := octollm.NewEmptyRequest(ctx)
+	r.Format = octollm.APIFormatChatCompletions
+	r.Body = octollm.NewBodyFromBytes([]byte(`{"model":"m"}`), &octollm.JSONParser[openai.ChatCompletionRequest]{})
+	return r
+}
+
+func TestNonStreamToStream_MergesChunks(t *testing.T) {
+	var gotStreamFlag, gotIsStreamCtx bool
+	next := octollm.EngineFunc(func(req *octollm.Request) (*octollm.Response, error) {
+		b, _ := req.Body.Bytes()
+		gotStreamFlag = gjson.GetBytes(b, "stream").Bool()
+		v, _ := octollm.GetCtxValue[bool](req, octollm.ContextKeyIsStream)
+		gotIsStreamCtx = v
+		return streamFromChunks(
+			`{"id":"cmpl-1","created":100,"model":"m","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello"}}]}`,
+			`{"id":"cmpl-1","model":"m","choices":[{"index":0,"delta":{"content":", world"}}]}`,
+			`{"id":"cmpl-1","model":"m","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+			`{"id":"cmpl-1","model":"m","choices":[],"usage":{"prompt_tokens":3,"completion_tokens":2,"total_tokens":5}}`,
+			`[DONE]`,
+		), nil
+	})
+
+	resp, err := NewNonStreamToStreamEngine(next).Process(chatReq(context.Background()))
+	if err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+	if !gotStreamFlag {
+		t.Error("downstream request body should have stream:true")
+	}
+	if !gotIsStreamCtx {
+		t.Error("downstream context should report stream via ContextKeyIsStream")
+	}
+	if resp.Stream != nil {
+		t.Fatal("response should be non-stream")
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+
+	parsed, err := resp.Body.Parsed()
+	if err != nil {
+		t.Fatalf("parse merged body: %v", err)
+	}
+	merged := parsed.(*openai.ChatCompletionResponse)
+	if merged.ID != "cmpl-1" || merged.Object != "chat.completion" {
+		t.Errorf("unexpected fields: %+v", merged)
+	}
+	if len(merged.Choices) != 1 {
+		t.Fatalf("choices = %d, want 1", len(merged.Choices))
+	}
+	c := merged.Choices[0]
+	if got := c.Message.Content.ExtractText(); got != "Hello, world" {
+		t.Errorf("content = %q, want %q", got, "Hello, world")
+	}
+	if c.FinishReason != "stop" {
+		t.Errorf("finish_reason = %q, want stop", c.FinishReason)
+	}
+	if merged.Usage == nil || merged.Usage.TotalTokens != 5 {
+		t.Errorf("usage = %+v, want total 5", merged.Usage)
+	}
+}
+
+func TestNonStreamToStream_PassthroughStreamRequest(t *testing.T) {
+	called := false
+	next := octollm.EngineFunc(func(req *octollm.Request) (*octollm.Response, error) {
+		called = true
+		if v, _ := octollm.GetCtxValue[bool](req, octollm.ContextKeyIsStream); !v {
+			t.Error("expected stream context to be preserved")
+		}
+		return streamFromChunks(`[DONE]`), nil
+	})
+
+	ctx := context.WithValue(context.Background(), octollm.ContextKeyIsStream, true)
+	resp, err := NewNonStreamToStreamEngine(next).Process(chatReq(ctx))
+	if err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+	if !called {
+		t.Fatal("next engine not called")
+	}
+	if resp.Stream == nil {
+		t.Error("stream request should pass through as stream response")
+	}
+}
+
+func TestNonStreamToStream_PassthroughUnsupportedFormat(t *testing.T) {
+	var gotFormat octollm.APIFormat
+	next := octollm.EngineFunc(func(req *octollm.Request) (*octollm.Response, error) {
+		gotFormat = req.Format
+		b, _ := req.Body.Bytes()
+		if gjson.GetBytes(b, "stream").Exists() {
+			t.Error("unsupported format must not have stream flipped")
+		}
+		return octollm.NewNonStreamResponse(200, http.Header{}, octollm.NewBodyFromBytes([]byte(`{}`), &octollm.JSONParser[openai.EmbeddingResponse]{})), nil
+	})
+
+	r := octollm.NewEmptyRequest(context.Background())
+	r.Format = octollm.APIFormatEmbeddings
+	r.Body = octollm.NewBodyFromBytes([]byte(`{"model":"m"}`), &octollm.JSONParser[openai.EmbeddingRequest]{})
+
+	resp, err := NewNonStreamToStreamEngine(next).Process(r)
+	if err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+	if gotFormat != octollm.APIFormatEmbeddings {
+		t.Errorf("format = %q, want embeddings", gotFormat)
+	}
+	if resp.Stream != nil {
+		t.Error("embeddings response should stay non-stream")
+	}
+}
+
+func TestNonStreamToStream_NonStreamUpstreamPassthrough(t *testing.T) {
+	next := octollm.EngineFunc(func(req *octollm.Request) (*octollm.Response, error) {
+		// Upstream short-circuits with a plain non-stream body (e.g. an error).
+		return octollm.NewNonStreamResponse(429, http.Header{}, octollm.NewBodyFromBytes([]byte(`{"error":"rate"}`), &octollm.JSONParser[openai.ChatCompletionResponse]{})), nil
+	})
+
+	resp, err := NewNonStreamToStreamEngine(next).Process(chatReq(context.Background()))
+	if err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+	if resp.StatusCode != 429 {
+		t.Errorf("status = %d, want 429 (passed through)", resp.StatusCode)
+	}
+}
+
+// TestNonStreamToStream_AllowlistBypass confirms WithEnabledFormats restricts the
+// engine to the listed formats; a chat/completions request is left untouched when
+// only Claude messages is enabled, even though chat/completions has a merger.
+func TestNonStreamToStream_AllowlistBypass(t *testing.T) {
+	var gotStreamFlag bool
+	next := octollm.EngineFunc(func(req *octollm.Request) (*octollm.Response, error) {
+		b, _ := req.Body.Bytes()
+		gotStreamFlag = gjson.GetBytes(b, "stream").Bool()
+		return octollm.NewNonStreamResponse(200, http.Header{}, octollm.NewBodyFromBytes([]byte(`{}`), &octollm.JSONParser[openai.ChatCompletionResponse]{})), nil
+	})
+
+	eng := NewNonStreamToStreamEngine(next, WithEnabledFormats(octollm.APIFormatClaudeMessages))
+	resp, err := eng.Process(chatReq(context.Background()))
+	if err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+	if gotStreamFlag {
+		t.Error("chat/completions should pass through unflipped when not in the allowlist")
+	}
+	if resp.Stream != nil {
+		t.Error("response should pass through unchanged")
+	}
+}

--- a/pkg/internal/testhelper/helper.go
+++ b/pkg/internal/testhelper/helper.go
@@ -15,12 +15,14 @@ import (
 	"github.com/infinigence/octollm/pkg/octollm"
 	"github.com/infinigence/octollm/pkg/types/anthropic"
 	"github.com/infinigence/octollm/pkg/types/openai"
+	"github.com/infinigence/octollm/pkg/types/vertex"
 )
 
 type reqOptions struct {
 	ctx        context.Context
 	HttpMethod string
 	URL        string
+	Format     octollm.APIFormat
 	Body       io.Reader
 	ReqParser  octollm.Parser
 
@@ -46,6 +48,7 @@ func defaultReqOpts() *reqOptions {
 	return &reqOptions{
 		HttpMethod: http.MethodPost,
 		URL:        "http://localhost:8000/v1/chat/completions",
+		Format:     octollm.APIFormatChatCompletions,
 		ReqParser:  &octollm.JSONParser[openai.ChatCompletionRequest]{},
 		Body:       bytes.NewReader(bodyJSON),
 	}
@@ -72,7 +75,7 @@ func CreateTestRequest(opts ...reqOptFunc) *octollm.Request {
 	}
 
 	parser := o.ReqParser
-	req := octollm.NewRequest(r, octollm.APIFormatChatCompletions)
+	req := octollm.NewRequest(r, o.Format)
 	req.Body.SetParser(parser)
 
 	// When custom features are set, register them so Get(req) will include them (no context storage).
@@ -101,6 +104,11 @@ func WithBody(body any) reqOptFunc {
 			opts.Body = bytes.NewReader(v)
 		case anthropic.ClaudeMessagesRequest:
 			opts.ReqParser = &octollm.JSONParser[anthropic.ClaudeMessagesRequest]{}
+			buffer, _ := json.Marshal(v)
+			opts.Body = bytes.NewReader(buffer)
+		case vertex.GenerateContentRequest:
+			opts.ReqParser = &octollm.JSONParser[vertex.GenerateContentRequest]{}
+			opts.Format = octollm.APIFormatGoogleGenerateContent
 			buffer, _ := json.Marshal(v)
 			opts.Body = bytes.NewReader(buffer)
 		default:

--- a/pkg/octollm/handler.go
+++ b/pkg/octollm/handler.go
@@ -28,7 +28,10 @@ const (
 	ContextKeyAction         contextKey = "action"
 	ContextKeyReceivedHeader contextKey = "received_header"
 	ContextKeyStreamSignaler contextKey = "stream_signaler"
-	ContextKeyIsStream       contextKey = "is_stream"
+	// ContextKeyIsStream caches the request's stream classification; it is set
+	// by Request.IsStream and should not be set by hand except to override the
+	// streamness of a derived request (see NonStreamToStreamEngine).
+	ContextKeyIsStream contextKey = "is_stream"
 	ContextKeyIsSSE          contextKey = "is_sse"
 )
 
@@ -304,45 +307,6 @@ func httpJSONArrayHandler(engine Engine, format APIFormat, parser Parser) http.H
 
 func IsStreamAction(action string) bool {
 	return strings.HasPrefix(strings.ToLower(action), "stream")
-}
-
-// IsStreamRequest reports whether req asks for a streaming response, using
-// whichever signal the protocol carries. It returns an error only when a
-// body-based protocol's body cannot be parsed.
-//
-// Detection order:
-//  1. ContextKeyIsStream, the resolved flag set once the request is classified
-//     — authoritative when present.
-//  2. ContextKeyAction, for URL-action protocols (e.g. Vertex
-//     streamGenerateContent) where streaming is not a body field.
-//  3. the typed request body's stream flag, for body-based protocols
-//     (OpenAI chat/completions & completions, Responses, Claude messages).
-func IsStreamRequest(req *Request) (bool, error) {
-	if v, ok := GetCtxValue[bool](req, ContextKeyIsStream); ok {
-		return v, nil
-	}
-	if action, ok := GetCtxValue[string](req, ContextKeyAction); ok {
-		return IsStreamAction(action), nil
-	}
-	if req == nil || req.Body == nil {
-		return false, nil
-	}
-
-	parsed, err := req.Body.Parsed()
-	if err != nil {
-		return false, err
-	}
-	switch body := parsed.(type) {
-	case *openai.ChatCompletionRequest:
-		return body.Stream != nil && *body.Stream, nil
-	case *openai.CompletionRequest:
-		return body.Stream, nil
-	case *openai.ResponsesRequest:
-		return body.Stream != nil && *body.Stream, nil
-	case *anthropic.ClaudeMessagesRequest:
-		return body.Stream != nil && *body.Stream, nil
-	}
-	return false, nil
 }
 
 // VertexAIHandler handles Google VertexAI/Gemini generateContent requests

--- a/pkg/octollm/handler.go
+++ b/pkg/octollm/handler.go
@@ -306,6 +306,45 @@ func IsStreamAction(action string) bool {
 	return strings.HasPrefix(strings.ToLower(action), "stream")
 }
 
+// IsStreamRequest reports whether req asks for a streaming response, using
+// whichever signal the protocol carries. It returns an error only when a
+// body-based protocol's body cannot be parsed.
+//
+// Detection order:
+//  1. ContextKeyIsStream, the resolved flag set once the request is classified
+//     — authoritative when present.
+//  2. ContextKeyAction, for URL-action protocols (e.g. Vertex
+//     streamGenerateContent) where streaming is not a body field.
+//  3. the typed request body's stream flag, for body-based protocols
+//     (OpenAI chat/completions & completions, Responses, Claude messages).
+func IsStreamRequest(req *Request) (bool, error) {
+	if v, ok := GetCtxValue[bool](req, ContextKeyIsStream); ok {
+		return v, nil
+	}
+	if action, ok := GetCtxValue[string](req, ContextKeyAction); ok {
+		return IsStreamAction(action), nil
+	}
+	if req == nil || req.Body == nil {
+		return false, nil
+	}
+
+	parsed, err := req.Body.Parsed()
+	if err != nil {
+		return false, err
+	}
+	switch body := parsed.(type) {
+	case *openai.ChatCompletionRequest:
+		return body.Stream != nil && *body.Stream, nil
+	case *openai.CompletionRequest:
+		return body.Stream, nil
+	case *openai.ResponsesRequest:
+		return body.Stream != nil && *body.Stream, nil
+	case *anthropic.ClaudeMessagesRequest:
+		return body.Stream != nil && *body.Stream, nil
+	}
+	return false, nil
+}
+
 // VertexAIHandler handles Google VertexAI/Gemini generateContent requests
 func VertexAIHandler(engine Engine) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/octollm/request.go
+++ b/pkg/octollm/request.go
@@ -8,6 +8,9 @@ import (
 	"net/http"
 	"net/url"
 	"sync"
+
+	"github.com/infinigence/octollm/pkg/types/anthropic"
+	"github.com/infinigence/octollm/pkg/types/openai"
 )
 
 type APIFormat string
@@ -318,6 +321,78 @@ func (u *Request) WithContext(ctx context.Context) *Request {
 	*u2 = *u
 	u2.ctx = ctx
 	return u2
+}
+
+// IsStream reports whether the request asks for a streaming response, using
+// whichever signal the protocol carries. It returns an error only when a
+// body-based protocol's body cannot be parsed.
+//
+// Detection order:
+//  1. ContextKeyIsStream — the cached (or deliberately overridden) flag,
+//     authoritative when present.
+//  2. ContextKeyAction, for URL-action protocols (e.g. Vertex
+//     streamGenerateContent) where streaming is not a body field.
+//  3. the typed request body's stream flag, for body-based protocols
+//     (OpenAI chat/completions & completions, Responses, Claude messages).
+//
+// On a successful classification the result is cached by replacing u's context
+// with one carrying ContextKeyIsStream, so later calls (including on engines
+// downstream of the same *Request) skip re-parsing. Two consequences:
+//
+//   - A successful call changes what u.Context() returns. Do not assume the
+//     context is stable across a call, and do not install a context derived
+//     from a pre-call u.Context() snapshot afterwards — that silently drops
+//     the cached flag (harmless, it is recomputed, but wasteful).
+//   - The ctx swap is not synchronized; like Body, a Request must not be
+//     accessed concurrently.
+//
+// Because of this caching, engines never need to set ContextKeyIsStream
+// themselves. The one exception is an engine that changes the streamness of a
+// request (e.g. NonStreamToStreamEngine): it must set the key on the derived
+// request's context to override the possibly-cached stale value.
+func (u *Request) IsStream() (bool, error) {
+	if u == nil {
+		return false, nil
+	}
+	if v, ok := GetCtxValue[bool](u, ContextKeyIsStream); ok {
+		return v, nil
+	}
+	isStream, err := u.detectIsStream()
+	if err != nil {
+		return false, err
+	}
+	if u.ctx != nil {
+		u.ctx = context.WithValue(u.ctx, ContextKeyIsStream, isStream)
+	}
+	return isStream, nil
+}
+
+// detectIsStream computes the stream flag from the action or the parsed body,
+// ignoring any cached value. Formats without a stream signal (embeddings,
+// rerank, unknown bodies) are non-stream.
+func (u *Request) detectIsStream() (bool, error) {
+	if action, ok := GetCtxValue[string](u, ContextKeyAction); ok {
+		return IsStreamAction(action), nil
+	}
+	if u.Body == nil {
+		return false, nil
+	}
+
+	parsed, err := u.Body.Parsed()
+	if err != nil {
+		return false, err
+	}
+	switch body := parsed.(type) {
+	case *openai.ChatCompletionRequest:
+		return body.Stream != nil && *body.Stream, nil
+	case *openai.CompletionRequest:
+		return body.Stream, nil
+	case *openai.ResponsesRequest:
+		return body.Stream != nil && *body.Stream, nil
+	case *anthropic.ClaudeMessagesRequest:
+		return body.Stream != nil && *body.Stream, nil
+	}
+	return false, nil
 }
 
 func GetCtxValue[T any](req *Request, key any) (T, bool) {

--- a/pkg/octollm/request_test.go
+++ b/pkg/octollm/request_test.go
@@ -1,0 +1,78 @@
+package octollm_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/infinigence/octollm/pkg/internal/testhelper"
+	"github.com/infinigence/octollm/pkg/octollm"
+	"github.com/infinigence/octollm/pkg/types/vertex"
+)
+
+func TestRequestIsStream(t *testing.T) {
+	t.Run("detects stream from body", func(t *testing.T) {
+		req := testhelper.CreateTestRequest(testhelper.WithBody(`{"model":"m","stream":true}`))
+		isStream, err := req.IsStream()
+		require.NoError(t, err)
+		assert.True(t, isStream)
+	})
+
+	t.Run("caches result into context", func(t *testing.T) {
+		req := testhelper.CreateTestRequest(testhelper.WithBody(`{"model":"m","stream":true}`))
+
+		_, ok := octollm.GetCtxValue[bool](req, octollm.ContextKeyIsStream)
+		assert.False(t, ok, "flag must not be set before the first call")
+
+		_, err := req.IsStream()
+		require.NoError(t, err)
+
+		v, ok := octollm.GetCtxValue[bool](req, octollm.ContextKeyIsStream)
+		assert.True(t, ok, "flag must be cached after the first call")
+		assert.True(t, v)
+	})
+
+	t.Run("vertex stream action is detected and cached", func(t *testing.T) {
+		// A URL-action protocol: VertexAIHandler extracts the action from the
+		// URL and stores it in the context; the Gemini body has no stream field.
+		ctx := context.WithValue(context.Background(), octollm.ContextKeyAction, "streamGenerateContent")
+		req := testhelper.CreateTestRequest(
+			testhelper.WithContext(ctx),
+			testhelper.WithBody(vertex.GenerateContentRequest{
+				Contents: []vertex.Content{
+					{Role: "user", Parts: []vertex.Part{{Text: "who are you?"}}},
+				},
+			}),
+		)
+		isStream, err := req.IsStream()
+		require.NoError(t, err)
+		assert.True(t, isStream)
+
+		v, ok := octollm.GetCtxValue[bool](req, octollm.ContextKeyIsStream)
+		assert.True(t, ok)
+		assert.True(t, v)
+	})
+
+	t.Run("parse error is returned and not cached", func(t *testing.T) {
+		req := testhelper.CreateTestRequest(testhelper.WithBody(`not json`))
+		_, err := req.IsStream()
+		require.Error(t, err)
+
+		_, ok := octollm.GetCtxValue[bool](req, octollm.ContextKeyIsStream)
+		assert.False(t, ok, "a failed classification must not be cached")
+	})
+
+	t.Run("nil request and nil body are non-stream", func(t *testing.T) {
+		var nilReq *octollm.Request
+		isStream, err := nilReq.IsStream()
+		require.NoError(t, err)
+		assert.False(t, isStream)
+
+		req := octollm.NewEmptyRequest(context.Background())
+		isStream, err = req.IsStream()
+		require.NoError(t, err)
+		assert.False(t, isStream)
+	})
+}

--- a/pkg/streammerge/chatcompletion.go
+++ b/pkg/streammerge/chatcompletion.go
@@ -73,9 +73,11 @@ func (m *chatCompletionMerger) Merge(chunk *octollm.StreamChunk) error {
 	if resp.Created != 0 {
 		m.result.Created = resp.Created
 	}
-	// Usage only appears on the final chunk (stream_options.include_usage).
+	// Usage only appears on the final chunk (stream_options.include_usage),
+	// but merge field-by-field so multiple usage-bearing chunks accumulate
+	// instead of the later one clobbering the earlier.
 	if resp.Usage != nil {
-		m.result.Usage = resp.Usage
+		m.result.Usage = mergeChatCompletionUsage(m.result.Usage, resp.Usage)
 	}
 
 	for _, sc := range resp.Choices {
@@ -112,6 +114,72 @@ func (m *chatCompletionMerger) Merge(chunk *octollm.StreamChunk) error {
 		}
 	}
 	return nil
+}
+
+// mergeChatCompletionUsage folds a usage object from a chunk into the running
+// total field-by-field, so token counts spread across multiple usage-bearing
+// chunks accumulate rather than a later chunk clobbering the earlier one. A
+// non-zero src field overrides dst; zero fields are left untouched.
+func mergeChatCompletionUsage(dst, src *openai.Usage) *openai.Usage {
+	if src == nil {
+		return dst
+	}
+	if dst == nil {
+		cp := *src
+		return &cp
+	}
+	if src.CompletionTokens != 0 {
+		dst.CompletionTokens = src.CompletionTokens
+	}
+	if src.PromptTokens != 0 {
+		dst.PromptTokens = src.PromptTokens
+	}
+	if src.TotalTokens != 0 {
+		dst.TotalTokens = src.TotalTokens
+	}
+	dst.CompletionTokensDetails = mergeCompletionTokensDetails(dst.CompletionTokensDetails, src.CompletionTokensDetails)
+	dst.PromptTokensDetails = mergePromptTokensDetails(dst.PromptTokensDetails, src.PromptTokensDetails)
+	return dst
+}
+
+// mergeCompletionTokensDetails folds completion-token detail fields into the
+// running total, so a non-zero src field overrides dst and zero fields are left
+// untouched (rather than the whole pointer being replaced).
+func mergeCompletionTokensDetails(dst, src *openai.CompletionTokensDetails) *openai.CompletionTokensDetails {
+	if src == nil {
+		return dst
+	}
+	if dst == nil {
+		cp := *src
+		return &cp
+	}
+	if src.ReasoningTokens != 0 {
+		dst.ReasoningTokens = src.ReasoningTokens
+	}
+	if src.AudioTokens != 0 {
+		dst.AudioTokens = src.AudioTokens
+	}
+	return dst
+}
+
+// mergePromptTokensDetails folds prompt-token detail fields into the running
+// total, so a non-zero src field overrides dst and zero fields are left
+// untouched (rather than the whole pointer being replaced).
+func mergePromptTokensDetails(dst, src *openai.PromptTokensDetails) *openai.PromptTokensDetails {
+	if src == nil {
+		return dst
+	}
+	if dst == nil {
+		cp := *src
+		return &cp
+	}
+	if src.CachedTokens != 0 {
+		dst.CachedTokens = src.CachedTokens
+	}
+	if src.AudioTokens != 0 {
+		dst.AudioTokens = src.AudioTokens
+	}
+	return dst
 }
 
 // mergeToolCall folds a streamed tool-call delta into the choice, accumulating

--- a/pkg/streammerge/chatcompletion.go
+++ b/pkg/streammerge/chatcompletion.go
@@ -1,0 +1,194 @@
+package streammerge
+
+import (
+	"errors"
+	"sort"
+	"strings"
+
+	"github.com/infinigence/octollm/pkg/octollm"
+	"github.com/infinigence/octollm/pkg/types/openai"
+)
+
+// chatCompletionMerger accumulates OpenAI chat.completion.chunk SSE events into
+// a single chat.completion response.
+//
+// Streamed text fragments are gathered in strings.Builder accumulators and
+// materialized once in finalize, so building the result is O(total bytes)
+// rather than the O(n^2) of repeated string concatenation.
+type chatCompletionMerger struct {
+	result    openai.ChatCompletionResponse
+	choices   map[int]*chatChoiceAcc
+	finalized bool
+}
+
+// chatChoiceAcc accumulates the streamed deltas for a single choice index.
+type chatChoiceAcc struct {
+	index        int
+	role         string
+	finishReason string
+	content      strings.Builder
+	sawContent   bool
+	reasoning    strings.Builder
+	sawReasoning bool
+	toolCalls    []*chatToolCallAcc // matched by tool-call index
+}
+
+// chatToolCallAcc accumulates the streamed fragments of one tool call.
+type chatToolCallAcc struct {
+	index   int
+	id      string
+	typ     string
+	hasFunc bool
+	name    strings.Builder
+	args    strings.Builder
+}
+
+// NewChatCompletionMerger returns a Merger for OpenAI chat/completions streams.
+func NewChatCompletionMerger() Merger {
+	return &chatCompletionMerger{
+		result:  openai.ChatCompletionResponse{Object: "chat.completion"},
+		choices: make(map[int]*chatChoiceAcc),
+	}
+}
+
+func (m *chatCompletionMerger) Merge(chunk *octollm.StreamChunk) error {
+	parsed, err := chunk.Body.Parsed()
+	if err != nil {
+		if errors.Is(err, octollm.ErrStreamDone) {
+			return nil
+		}
+		return err
+	}
+	resp, ok := parsed.(*openai.ChatCompletionStreamChunk)
+	if !ok || resp == nil {
+		return nil // unexpected type or terminator
+	}
+
+	if resp.ID != "" {
+		m.result.ID = resp.ID
+	}
+	if resp.Model != "" {
+		m.result.Model = resp.Model
+	}
+	if resp.Created != 0 {
+		m.result.Created = resp.Created
+	}
+	// Usage only appears on the final chunk (stream_options.include_usage).
+	if resp.Usage != nil {
+		m.result.Usage = resp.Usage
+	}
+
+	for _, sc := range resp.Choices {
+		if sc == nil {
+			continue
+		}
+		acc, ok := m.choices[sc.Index]
+		if !ok {
+			acc = &chatChoiceAcc{index: sc.Index}
+			m.choices[sc.Index] = acc
+		}
+		if sc.FinishReason != "" {
+			acc.finishReason = sc.FinishReason
+		}
+		d := sc.Delta
+		if d == nil {
+			continue
+		}
+		if d.Role != "" {
+			acc.role = d.Role
+		}
+		// Non-string content (arrays) is not expected in chat deltas; only the
+		// streamed string fragments are accumulated.
+		if s, ok := d.Content.(openai.MessageContentString); ok {
+			acc.content.WriteString(string(s))
+			acc.sawContent = true
+		}
+		if s, ok := d.ReasoningContent.(openai.MessageContentString); ok {
+			acc.reasoning.WriteString(string(s))
+			acc.sawReasoning = true
+		}
+		for _, tc := range d.ToolCalls {
+			acc.mergeToolCall(tc)
+		}
+	}
+	return nil
+}
+
+// mergeToolCall folds a streamed tool-call delta into the choice, accumulating
+// function name/arguments fragments for the matching call index.
+func (a *chatChoiceAcc) mergeToolCall(delta *openai.MessageToolCall) {
+	if delta == nil {
+		return
+	}
+	var tc *chatToolCallAcc
+	for _, existing := range a.toolCalls {
+		if existing.index == delta.Index {
+			tc = existing
+			break
+		}
+	}
+	if tc == nil {
+		tc = &chatToolCallAcc{index: delta.Index}
+		a.toolCalls = append(a.toolCalls, tc)
+	}
+	if delta.ID != "" {
+		tc.id = delta.ID
+	}
+	if delta.Type != "" {
+		tc.typ = delta.Type
+	}
+	if delta.Function != nil {
+		tc.hasFunc = true
+		tc.name.WriteString(delta.Function.Name)
+		tc.args.WriteString(delta.Function.Arguments)
+	}
+}
+
+// build materializes the accumulated deltas into a final choice.
+func (a *chatChoiceAcc) build() *openai.ChatCompletionChoice {
+	msg := &openai.Message{Role: a.role}
+	if a.sawContent {
+		msg.Content = openai.MessageContentString(a.content.String())
+	}
+	if a.sawReasoning {
+		msg.ReasoningContent = openai.MessageContentString(a.reasoning.String())
+	}
+	if len(a.toolCalls) > 0 {
+		msg.ToolCalls = make([]*openai.MessageToolCall, 0, len(a.toolCalls))
+		for _, tc := range a.toolCalls {
+			mtc := &openai.MessageToolCall{Index: tc.index, ID: tc.id, Type: tc.typ}
+			if tc.hasFunc {
+				mtc.Function = &openai.ToolCallFunction{
+					Name:      tc.name.String(),
+					Arguments: tc.args.String(),
+				}
+			}
+			msg.ToolCalls = append(msg.ToolCalls, mtc)
+		}
+	}
+	return &openai.ChatCompletionChoice{
+		Index:        a.index,
+		FinishReason: a.finishReason,
+		Message:      msg,
+	}
+}
+
+func (m *chatCompletionMerger) finalize() {
+	if m.finalized {
+		return
+	}
+	m.finalized = true
+	choices := make([]*openai.ChatCompletionChoice, 0, len(m.choices))
+	for _, acc := range m.choices {
+		choices = append(choices, acc.build())
+	}
+	sort.Slice(choices, func(i, j int) bool {
+		return choices[i].Index < choices[j].Index
+	})
+	m.result.Choices = choices
+}
+
+func (m *chatCompletionMerger) Merged() (*octollm.UnifiedBody, error) {
+	m.finalize()
+	return octollm.NewBodyFromParsed(&m.result, &octollm.JSONParser[openai.ChatCompletionResponse]{}), nil
+}

--- a/pkg/streammerge/chatcompletion_test.go
+++ b/pkg/streammerge/chatcompletion_test.go
@@ -1,0 +1,109 @@
+package streammerge
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/infinigence/octollm/pkg/octollm"
+	"github.com/infinigence/octollm/pkg/types/openai"
+)
+
+// runChatMerge feeds the raw chat.completion.chunk SSE payloads through the
+// merger (parsed exactly as the client emits them) and asserts the assembled
+// non-stream response equals expectedJSON.
+func runChatMerge(t *testing.T, chunks []string, expectedJSON string) {
+	t.Helper()
+	m := NewChatCompletionMerger()
+	for _, c := range chunks {
+		body := octollm.NewBodyFromBytes([]byte(c), &octollm.JSONParser[openai.ChatCompletionStreamChunk]{})
+		if err := m.Merge(&octollm.StreamChunk{Body: body}); err != nil {
+			t.Fatalf("Merge(%s): %v", c, err)
+		}
+	}
+	merged, err := m.Merged()
+	require.NoError(t, err)
+	got, err := merged.Bytes()
+	require.NoError(t, err)
+	require.JSONEq(t, expectedJSON, string(got))
+}
+
+// Stream fixtures mirror the openaiRespJSON inputs in
+// pkg/engines/converter/claude_test.go, so the merger is exercised against the
+// same real upstream payloads the protocol converter handles.
+
+func TestChatCompletionMerger_SimpleText(t *testing.T) {
+	runChatMerge(t, []string{
+		`{"id":"c91dda37dc3c4018ac0fecf81cf0052d","object":"chat.completion.chunk","created":1765734075,"model":"Kimi-K2-Instruct","choices":[{"index":0,"delta":{"role":"assistant","content":"","tool_calls":null},"logprobs":null,"finish_reason":null,"matched_stop":null}]}`,
+		`{"id":"c91dda37dc3c4018ac0fecf81cf0052d","object":"chat.completion.chunk","created":1765734075,"model":"Kimi-K2-Instruct","choices":[{"index":0,"delta":{"content":"I'm","tool_calls":null},"logprobs":null,"finish_reason":null,"matched_stop":null}]}`,
+		`{"id":"c91dda37dc3c4018ac0fecf81cf0052d","object":"chat.completion.chunk","created":1765734075,"model":"Kimi-K2-Instruct","choices":[{"index":0,"delta":{"content":" Kim","tool_calls":null},"logprobs":null,"finish_reason":null,"matched_stop":null}]}`,
+		`{"id":"c91dda37dc3c4018ac0fecf81cf0052d","object":"chat.completion.chunk","created":1765734075,"model":"Kimi-K2-Instruct","choices":[{"index":0,"delta":{"content":"i","tool_calls":null},"logprobs":null,"finish_reason":null,"matched_stop":null}]}`,
+		`{"id":"c91dda37dc3c4018ac0fecf81cf0052d","object":"chat.completion.chunk","created":1765734075,"model":"Kimi-K2-Instruct","choices":[{"index":0,"delta":{"content":",","tool_calls":null},"logprobs":null,"finish_reason":null,"matched_stop":null}]}`,
+		`{"id":"c91dda37dc3c4018ac0fecf81cf0052d","object":"chat.completion.chunk","created":1765734075,"model":"Kimi-K2-Instruct","choices":[{"index":0,"delta":{"content":" a","tool_calls":null},"logprobs":null,"finish_reason":null,"matched_stop":null}]}`,
+		`{"id":"c91dda37dc3c4018ac0fecf81cf0052d","object":"chat.completion.chunk","created":1765734075,"model":"Kimi-K2-Instruct","choices":[{"index":0,"delta":{"content":" large","tool_calls":null},"logprobs":null,"finish_reason":null,"matched_stop":null}]}`,
+		`{"id":"c91dda37dc3c4018ac0fecf81cf0052d","object":"chat.completion.chunk","created":1765734075,"model":"Kimi-K2-Instruct","choices":[{"index":0,"delta":{"content":" language","tool_calls":null},"logprobs":null,"finish_reason":null,"matched_stop":null}]}`,
+		`{"id":"c91dda37dc3c4018ac0fecf81cf0052d","object":"chat.completion.chunk","created":1765734075,"model":"Kimi-K2-Instruct","choices":[{"index":0,"delta":{"content":" model","tool_calls":null},"logprobs":null,"finish_reason":null,"matched_stop":null}]}`,
+		`{"id":"c91dda37dc3c4018ac0fecf81cf0052d","object":"chat.completion.chunk","created":1765734075,"model":"Kimi-K2-Instruct","choices":[{"index":0,"delta":{"content":" trained","tool_calls":null},"logprobs":null,"finish_reason":null,"matched_stop":null}]}`,
+		`{"id":"c91dda37dc3c4018ac0fecf81cf0052d","object":"chat.completion.chunk","created":1765734075,"model":"Kimi-K2-Instruct","choices":[{"index":0,"delta":{"content":" by","tool_calls":null},"logprobs":null,"finish_reason":null,"matched_stop":null}]}`,
+		`{"id":"c91dda37dc3c4018ac0fecf81cf0052d","object":"chat.completion.chunk","created":1765734075,"model":"Kimi-K2-Instruct","choices":[{"index":0,"delta":{"content":" Moon","tool_calls":null},"logprobs":null,"finish_reason":null,"matched_stop":null}]}`,
+		`{"id":"c91dda37dc3c4018ac0fecf81cf0052d","object":"chat.completion.chunk","created":1765734075,"model":"Kimi-K2-Instruct","choices":[{"index":0,"delta":{"content":"shot","tool_calls":null},"logprobs":null,"finish_reason":null,"matched_stop":null}]}`,
+		`{"id":"c91dda37dc3c4018ac0fecf81cf0052d","object":"chat.completion.chunk","created":1765734075,"model":"Kimi-K2-Instruct","choices":[{"index":0,"delta":{"content":" AI","tool_calls":null},"logprobs":null,"finish_reason":null,"matched_stop":null}]}`,
+		`{"id":"c91dda37dc3c4018ac0fecf81cf0052d","object":"chat.completion.chunk","created":1765734075,"model":"Kimi-K2-Instruct","choices":[{"index":0,"delta":{"content":".","tool_calls":null},"logprobs":null,"finish_reason":null,"matched_stop":null}]}`,
+		`{"id":"c91dda37dc3c4018ac0fecf81cf0052d","object":"chat.completion.chunk","created":1765734075,"model":"Kimi-K2-Instruct","choices":[{"index":0,"delta":{"content":"","tool_calls":null},"logprobs":null,"finish_reason":"stop","matched_stop":163586}]}`,
+		`{"id":"c91dda37dc3c4018ac0fecf81cf0052d","object":"chat.completion.chunk","created":1765734075,"model":"Kimi-K2-Instruct","choices":[],"usage":{"prompt_tokens":31,"total_tokens":46,"completion_tokens":15,"prompt_tokens_details":null,"reasoning_tokens":0}}`,
+		`[DONE]`,
+	}, `{"id":"c91dda37dc3c4018ac0fecf81cf0052d","created":1765734075,"object":"chat.completion","model":"Kimi-K2-Instruct","usage":{"completion_tokens":15,"prompt_tokens":31,"total_tokens":46},"choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","content":"I'm Kimi, a large language model trained by Moonshot AI."}}]}`)
+}
+
+func TestChatCompletionMerger_ToolCall(t *testing.T) {
+	runChatMerge(t, []string{
+		`{"id":"1480f67c3ad545f580a0742339bb391b","object":"chat.completion.chunk","created":1756124074,"model":"Kimi-K2-Instruct","choices":[{"index":0,"delta":{"role":"assistant","content":"","tool_calls":null},"logprobs":null,"finish_reason":null,"matched_stop":null}]}`,
+		`{"id":"1480f67c3ad545f580a0742339bb391b","object":"chat.completion.chunk","created":1756124074,"model":"Kimi-K2-Instruct","choices":[{"index":0,"delta":{"content":"我来","tool_calls":null},"logprobs":null,"finish_reason":null,"matched_stop":null}]}`,
+		`{"id":"1480f67c3ad545f580a0742339bb391b","object":"chat.completion.chunk","created":1756124074,"model":"Kimi-K2-Instruct","choices":[{"index":0,"delta":{"content":"帮你","tool_calls":null},"logprobs":null,"finish_reason":null,"matched_stop":null}]}`,
+		`{"id":"1480f67c3ad545f580a0742339bb391b","object":"chat.completion.chunk","created":1756124074,"model":"Kimi-K2-Instruct","choices":[{"index":0,"delta":{"content":"查","tool_calls":null},"logprobs":null,"finish_reason":null,"matched_stop":null}]}`,
+		`{"id":"1480f67c3ad545f580a0742339bb391b","object":"chat.completion.chunk","created":1756124074,"model":"Kimi-K2-Instruct","choices":[{"index":0,"delta":{"content":"一下","tool_calls":null},"logprobs":null,"finish_reason":null,"matched_stop":null}]}`,
+		`{"id":"1480f67c3ad545f580a0742339bb391b","object":"chat.completion.chunk","created":1756124074,"model":"Kimi-K2-Instruct","choices":[{"index":0,"delta":{"content":"。","tool_calls":null},"logprobs":null,"finish_reason":null,"matched_stop":null}]}`,
+		`{"id":"1480f67c3ad545f580a0742339bb391b","object":"chat.completion.chunk","created":1756124074,"model":"Kimi-K2-Instruct","choices":[{"index":0,"delta":{"content":"","tool_calls":[{"id":"functions.search:0","index":0,"type":"function","function":{"name":"search","arguments":""}}]},"logprobs":null,"finish_reason":null,"matched_stop":null}]}`,
+		`{"id":"1480f67c3ad545f580a0742339bb391b","object":"chat.completion.chunk","created":1756124074,"model":"Kimi-K2-Instruct","choices":[{"index":0,"delta":{"content":"","tool_calls":[{"id":null,"index":0,"type":"function","function":{"name":null,"arguments":"{\"queries"}}]},"logprobs":null,"finish_reason":null,"matched_stop":null}]}`,
+		`{"id":"1480f67c3ad545f580a0742339bb391b","object":"chat.completion.chunk","created":1756124074,"model":"Kimi-K2-Instruct","choices":[{"index":0,"delta":{"content":"","tool_calls":[{"id":null,"index":0,"type":"function","function":{"name":null,"arguments":"\":"}}]},"logprobs":null,"finish_reason":null,"matched_stop":null}]}`,
+		`{"id":"1480f67c3ad545f580a0742339bb391b","object":"chat.completion.chunk","created":1756124074,"model":"Kimi-K2-Instruct","choices":[{"index":0,"delta":{"content":"","tool_calls":[{"id":null,"index":0,"type":"function","function":{"name":null,"arguments":"1"}}]},"logprobs":null,"finish_reason":null,"matched_stop":null}]}`,
+		`{"id":"1480f67c3ad545f580a0742339bb391b","object":"chat.completion.chunk","created":1756124075,"model":"Kimi-K2-Instruct","choices":[{"index":0,"delta":{"content":"","tool_calls":[{"id":null,"index":0,"type":"function","function":{"name":null,"arguments":"}"}}]},"logprobs":null,"finish_reason":null,"matched_stop":null}]}`,
+		`{"id":"1480f67c3ad545f580a0742339bb391b","object":"chat.completion.chunk","created":1756124076,"model":"Kimi-K2-Instruct","choices":[{"index":0,"delta":{"content":"","tool_calls":null},"logprobs":null,"finish_reason":"tool_calls","matched_stop":163586}]}`,
+		`{"id":"1480f67c3ad545f580a0742339bb391b","object":"chat.completion.chunk","created":1756124076,"model":"Kimi-K2-Instruct","choices":[],"usage":{"prompt_tokens":177,"total_tokens":246,"completion_tokens":69,"prompt_tokens_details":null}}`,
+		`[DONE]`,
+	}, `{"id":"1480f67c3ad545f580a0742339bb391b","created":1756124076,"object":"chat.completion","model":"Kimi-K2-Instruct","usage":{"completion_tokens":69,"prompt_tokens":177,"total_tokens":246},"choices":[{"index":0,"finish_reason":"tool_calls","message":{"role":"assistant","content":"我来帮你查一下。","tool_calls":[{"id":"functions.search:0","index":0,"type":"function","function":{"name":"search","arguments":"{\"queries\":1}"}}]}}]}`)
+}
+
+func TestChatCompletionMerger_Reasoning(t *testing.T) {
+	runChatMerge(t, []string{
+		`{"id":"2026021010253871cb1b6ec9e54d6b","created":1770690338,"object":"chat.completion.chunk","model":"glm-4.6","choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":"\n"}}]}`,
+		`{"id":"2026021010253871cb1b6ec9e54d6b","created":1770690338,"object":"chat.completion.chunk","model":"glm-4.6","choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":"1"}}]}`,
+		`{"id":"2026021010253871cb1b6ec9e54d6b","created":1770690338,"object":"chat.completion.chunk","model":"glm-4.6","choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":"."}}]}`,
+		`{"id":"2026021010253871cb1b6ec9e54d6b","created":1770690338,"object":"chat.completion.chunk","model":"glm-4.6","choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":" "}}]}`,
+		`{"id":"2026021010253871cb1b6ec9e54d6b","created":1770690338,"object":"chat.completion.chunk","model":"glm-4.6","choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":" **"}}]}`,
+		`{"id":"2026021010253871cb1b6ec9e54d6b","created":1770690338,"object":"chat.completion.chunk","model":"glm-4.6","choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":"分析"}}]}`,
+		`{"id":"2026021010253871cb1b6ec9e54d6b","created":1770690338,"object":"chat.completion.chunk","model":"glm-4.6","choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":"用户的"}}]}`,
+		`{"id":"2026021010253871cb1b6ec9e54d6b","created":1770690338,"object":"chat.completion.chunk","model":"glm-4.6","choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":"查询"}}]}`,
+		`{"id":"2026021010253871cb1b6ec9e54d6b","created":1770690338,"object":"chat.completion.chunk","model":"glm-4.6","choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":"："}}]}`,
+		`{"id":"2026021010253871cb1b6ec9e54d6b","created":1770690338,"object":"chat.completion.chunk","model":"glm-4.6","choices":[{"index":0,"delta":{"role":"assistant","content":"\n"}}]}`,
+		`{"id":"2026021010253871cb1b6ec9e54d6b","created":1770690338,"object":"chat.completion.chunk","model":"glm-4.6","choices":[{"index":0,"delta":{"role":"assistant","content":"你好"}}]}`,
+		`{"id":"2026021010253871cb1b6ec9e54d6b","created":1770690338,"object":"chat.completion.chunk","model":"glm-4.6","choices":[{"index":0,"delta":{"role":"assistant","content":"！\n\n"}}]}`,
+		`{"id":"2026021010253871cb1b6ec9e54d6b","created":1770690338,"object":"chat.completion.chunk","model":"glm-4.6","choices":[{"index":0,"delta":{"role":"assistant","content":"我是一个"}}]}`,
+		`{"id":"2026021010253871cb1b6ec9e54d6b","created":1770690338,"object":"chat.completion.chunk","model":"glm-4.6","choices":[{"index":0,"delta":{"role":"assistant","content":"大型"}}]}`,
+		`{"id":"2026021010253871cb1b6ec9e54d6b","created":1770690338,"object":"chat.completion.chunk","model":"glm-4.6","choices":[{"index":0,"delta":{"role":"assistant","content":"语言"}}]}`,
+		`{"id":"2026021010253871cb1b6ec9e54d6b","created":1770690338,"object":"chat.completion.chunk","model":"glm-4.6","choices":[{"index":0,"delta":{"role":"assistant","content":"模型"}}]}`,
+		`{"id":"2026021010253871cb1b6ec9e54d6b","created":1770690338,"object":"chat.completion.chunk","model":"glm-4.6","choices":[{"index":0,"finish_reason":"stop","delta":{"role":"assistant","content":""}}]}`,
+		`{"id":"2026021010253871cb1b6ec9e54d6b","created":1770690338,"model":"glm-4.6","choices":[],"usage":{"completion_tokens":1024,"prompt_tokens":9,"total_tokens":1033,"prompt_tokens_details":{"cached_tokens":7}},"object":"chat.completion.chunk"}`,
+		`[DONE]`,
+	}, `{"id":"2026021010253871cb1b6ec9e54d6b","created":1770690338,"object":"chat.completion","model":"glm-4.6","usage":{"completion_tokens":1024,"prompt_tokens":9,"total_tokens":1033,"prompt_tokens_details":{"cached_tokens":7}},"choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","content":"\n你好！\n\n我是一个大型语言模型","reasoning_content":"\n1.  **分析用户的查询："}}]}`)
+}
+
+// TestChatCompletionMerger_MultipleChoices checks out-of-order choice indexes
+// are accumulated independently and emitted sorted by index.
+func TestChatCompletionMerger_MultipleChoices(t *testing.T) {
+	runChatMerge(t, []string{
+		`{"id":"x","model":"m","choices":[{"index":1,"delta":{"role":"assistant","content":"second"}}]}`,
+		`{"id":"x","model":"m","choices":[{"index":0,"delta":{"role":"assistant","content":"first"}}]}`,
+		`[DONE]`,
+	}, `{"id":"x","created":0,"object":"chat.completion","model":"m","usage":null,"choices":[{"index":0,"finish_reason":"","message":{"role":"assistant","content":"first"}},{"index":1,"finish_reason":"","message":{"role":"assistant","content":"second"}}]}`)
+}

--- a/pkg/streammerge/chatcompletion_test.go
+++ b/pkg/streammerge/chatcompletion_test.go
@@ -98,6 +98,21 @@ func TestChatCompletionMerger_Reasoning(t *testing.T) {
 	}, `{"id":"2026021010253871cb1b6ec9e54d6b","created":1770690338,"object":"chat.completion","model":"glm-4.6","usage":{"completion_tokens":1024,"prompt_tokens":9,"total_tokens":1033,"prompt_tokens_details":{"cached_tokens":7}},"choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","content":"\n你好！\n\n我是一个大型语言模型","reasoning_content":"\n1.  **分析用户的查询："}}]}`)
 }
 
+// TestChatCompletionMerger_UsageSplitAcrossChunks covers the corner case where
+// usage is dribbled out across chunks instead of arriving whole in the final
+// one: prompt_tokens_details (cached_tokens) shows up in the very first chunk,
+// while the closing usage chunk carries only the token totals and a nil
+// prompt_tokens_details. A whole-pointer assignment would let the final chunk
+// clobber the early cached_tokens; the field-by-field merge must preserve it.
+func TestChatCompletionMerger_UsageSplitAcrossChunks(t *testing.T) {
+	runChatMerge(t, []string{
+		`{"id":"u","model":"m","choices":[{"index":0,"delta":{"role":"assistant","content":"hi"}}],"usage":{"prompt_tokens":0,"total_tokens":0,"completion_tokens":0,"prompt_tokens_details":{"cached_tokens":7}}}`,
+		`{"id":"u","model":"m","choices":[{"index":0,"finish_reason":"stop","delta":{"content":""}}]}`,
+		`{"id":"u","model":"m","choices":[],"usage":{"prompt_tokens":31,"total_tokens":46,"completion_tokens":15,"prompt_tokens_details":null}}`,
+		`[DONE]`,
+	}, `{"id":"u","created":0,"object":"chat.completion","model":"m","usage":{"completion_tokens":15,"prompt_tokens":31,"total_tokens":46,"prompt_tokens_details":{"cached_tokens":7}},"choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","content":"hi"}}]}`)
+}
+
 // TestChatCompletionMerger_MultipleChoices checks out-of-order choice indexes
 // are accumulated independently and emitted sorted by index.
 func TestChatCompletionMerger_MultipleChoices(t *testing.T) {

--- a/pkg/streammerge/claude.go
+++ b/pkg/streammerge/claude.go
@@ -1,0 +1,225 @@
+package streammerge
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/infinigence/octollm/pkg/octollm"
+	"github.com/infinigence/octollm/pkg/types/anthropic"
+)
+
+// claudeMessagesMerger accumulates Anthropic Messages SSE events into a single
+// messages response. Events arrive as: message_start, then per content block
+// content_block_start / content_block_delta* / content_block_stop, then
+// message_delta and message_stop.
+//
+// Streamed text/thinking fragments are gathered in strings.Builder accumulators
+// and tool-use JSON in a byte slice, so the result is built in O(total bytes)
+// instead of the O(n^2) of repeated string concatenation.
+type claudeMessagesMerger struct {
+	response  anthropic.ClaudeMessagesResponse
+	blocks    []*claudeBlockAcc // indexed by content block index
+	finalized bool
+}
+
+// claudeBlockAcc accumulates the streamed deltas of one content block.
+type claudeBlockAcc struct {
+	kind      string // "text", "thinking", "tool_use", or "" for passthrough
+	id        string // tool_use
+	name      string // tool_use
+	text      strings.Builder
+	signature strings.Builder
+	input     []byte // tool_use partial JSON
+
+	// passthrough holds blocks that carry no deltas (redacted_thinking, unknown
+	// types) so they survive into the merged response unchanged.
+	passthrough anthropic.MessageContentBlockParam
+}
+
+// NewClaudeMessagesMerger returns a Merger for Anthropic Messages streams.
+func NewClaudeMessagesMerger() Merger {
+	return &claudeMessagesMerger{}
+}
+
+func (m *claudeMessagesMerger) Merge(chunk *octollm.StreamChunk) error {
+	parsed, err := chunk.Body.Parsed()
+	if err != nil {
+		if errors.Is(err, octollm.ErrStreamDone) {
+			return nil
+		}
+		return err
+	}
+	event, ok := parsed.(*anthropic.ClaudeMessagesStreamEvent)
+	if !ok || event == nil {
+		return nil
+	}
+
+	switch event.Type {
+	case "message_start":
+		if msg := event.Message; msg != nil {
+			if msg.ID != "" {
+				m.response.ID = msg.ID
+			}
+			if msg.Type != "" {
+				m.response.Type = msg.Type
+			}
+			if msg.Role != "" {
+				m.response.Role = msg.Role
+			}
+			if msg.Model != "" {
+				m.response.Model = msg.Model
+			}
+			m.response.Usage = mergeClaudeUsage(m.response.Usage, msg.Usage)
+		}
+
+	case "content_block_start":
+		idx := blockIndex(event)
+		for len(m.blocks) <= idx {
+			m.blocks = append(m.blocks, nil)
+		}
+		m.blocks[idx] = newBlockAcc(event.ContentBlock)
+
+	case "content_block_delta":
+		idx := blockIndex(event)
+		if idx < 0 || idx >= len(m.blocks) || m.blocks[idx] == nil {
+			return fmt.Errorf("streammerge: content_block_delta index %d out of range (len=%d)", idx, len(m.blocks))
+		}
+		if event.Delta != nil {
+			m.blocks[idx].applyDelta(&event.Delta.ContentBlockDelta)
+		}
+
+	case "message_delta":
+		if event.Delta != nil {
+			if event.Delta.StopReason != nil {
+				m.response.StopReason = *event.Delta.StopReason
+			}
+			if event.Delta.StopSequence != nil {
+				m.response.StopSequence = event.Delta.StopSequence
+			}
+		}
+		// message_delta usage carries the final output token count; merge it so
+		// the input/cache counts from message_start are preserved.
+		m.response.Usage = mergeClaudeUsage(m.response.Usage, event.Usage)
+	}
+	return nil
+}
+
+func blockIndex(event *anthropic.ClaudeMessagesStreamEvent) int {
+	if event.Index != nil {
+		return *event.Index
+	}
+	return 0
+}
+
+// newBlockAcc creates a fresh, empty accumulator for the block kind announced by
+// content_block_start. The start event's partial fields (e.g. an empty tool_use
+// input) are not reused to avoid double counting.
+func newBlockAcc(started anthropic.MessageContentBlockParam) *claudeBlockAcc {
+	switch b := started.(type) {
+	case *anthropic.TextBlockParam:
+		return &claudeBlockAcc{kind: "text"}
+	case *anthropic.ThinkingBlockParam:
+		return &claudeBlockAcc{kind: "thinking"}
+	case *anthropic.ToolUseBlockParam:
+		return &claudeBlockAcc{kind: "tool_use", id: b.ID, name: b.Name}
+	case nil:
+		return nil
+	default:
+		// redacted_thinking and unknown blocks have no deltas; keep as-is.
+		return &claudeBlockAcc{passthrough: started}
+	}
+}
+
+func (a *claudeBlockAcc) applyDelta(delta *anthropic.ContentBlockDelta) {
+	switch delta.Type {
+	case "text_delta":
+		if a.kind == "text" && delta.Text != nil {
+			a.text.WriteString(*delta.Text)
+		}
+	case "thinking_delta":
+		if a.kind == "thinking" && delta.Thinking != nil {
+			a.text.WriteString(*delta.Thinking)
+		}
+	case "signature_delta":
+		if a.kind == "thinking" && delta.Signature != nil {
+			a.signature.WriteString(*delta.Signature)
+		}
+	case "input_json_delta":
+		if a.kind == "tool_use" && delta.PartialJSON != nil {
+			a.input = append(a.input, []byte(*delta.PartialJSON)...)
+		}
+	}
+}
+
+// build materializes the accumulated deltas into a final content block.
+func (a *claudeBlockAcc) build() anthropic.MessageContentBlockParam {
+	switch a.kind {
+	case "text":
+		return &anthropic.TextBlockParam{Type: "text", Text: a.text.String()}
+	case "thinking":
+		return &anthropic.ThinkingBlockParam{
+			Type:      "thinking",
+			Thinking:  a.text.String(),
+			Signature: a.signature.String(),
+		}
+	case "tool_use":
+		input := json.RawMessage(a.input)
+		if len(input) == 0 {
+			// An empty tool_use input would marshal as invalid JSON; default to {}.
+			input = json.RawMessage("{}")
+		}
+		return &anthropic.ToolUseBlockParam{Type: "tool_use", ID: a.id, Name: a.name, Input: input}
+	default:
+		return a.passthrough
+	}
+}
+
+// mergeClaudeUsage overlays the non-nil token counts from src onto dst, so the
+// input/cache tokens (message_start) and output tokens (message_delta) combine
+// into one usage object instead of the later event clobbering the earlier one.
+func mergeClaudeUsage(dst, src *anthropic.Usage) *anthropic.Usage {
+	if src == nil {
+		return dst
+	}
+	if dst == nil {
+		cp := *src
+		return &cp
+	}
+	if src.InputTokens != nil {
+		dst.InputTokens = src.InputTokens
+	}
+	if src.OutputTokens != nil {
+		dst.OutputTokens = src.OutputTokens
+	}
+	if src.CacheCreationInputTokens != nil {
+		dst.CacheCreationInputTokens = src.CacheCreationInputTokens
+	}
+	if src.CacheReadInputTokens != nil {
+		dst.CacheReadInputTokens = src.CacheReadInputTokens
+	}
+	return dst
+}
+
+func (m *claudeMessagesMerger) finalize() {
+	if m.finalized {
+		return
+	}
+	m.finalized = true
+	content := make(anthropic.MessageContentBlockArray, 0, len(m.blocks))
+	for _, a := range m.blocks {
+		if a == nil {
+			continue
+		}
+		if b := a.build(); b != nil {
+			content = append(content, b)
+		}
+	}
+	m.response.Content = content
+}
+
+func (m *claudeMessagesMerger) Merged() (*octollm.UnifiedBody, error) {
+	m.finalize()
+	return octollm.NewBodyFromParsed(&m.response, &octollm.JSONParser[anthropic.ClaudeMessagesResponse]{}), nil
+}

--- a/pkg/streammerge/claude_test.go
+++ b/pkg/streammerge/claude_test.go
@@ -1,0 +1,189 @@
+package streammerge
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/infinigence/octollm/pkg/octollm"
+	"github.com/infinigence/octollm/pkg/types/anthropic"
+)
+
+// runClaudeMerge feeds the raw Claude Messages SSE events through the merger
+// (parsed as the client emits them) and asserts the assembled non-stream
+// response equals expectedJSON.
+func runClaudeMerge(t *testing.T, events []string, expectedJSON string) {
+	t.Helper()
+	m := NewClaudeMessagesMerger()
+	for _, e := range events {
+		body := octollm.NewBodyFromBytes([]byte(e), &octollm.JSONParser[anthropic.ClaudeMessagesStreamEvent]{})
+		if err := m.Merge(&octollm.StreamChunk{Body: body}); err != nil {
+			t.Fatalf("Merge(%s): %v", e, err)
+		}
+	}
+	merged, err := m.Merged()
+	require.NoError(t, err)
+	got, err := merged.Bytes()
+	require.NoError(t, err)
+	require.JSONEq(t, expectedJSON, string(got))
+}
+
+// Event fixtures are the expectedClaudeRespJSON streams from
+// pkg/engines/converter/claude_test.go: the Claude Messages SSE sequences the
+// merger must fold back into a single response.
+
+func TestClaudeMerger_SimpleText(t *testing.T) {
+	runClaudeMerge(t, []string{
+		`{"type":"message_start","message":{"id":"c91dda37dc3c4018ac0fecf81cf0052d","type":"message","role":"assistant","content":[],"model":"Kimi-K2-Instruct","usage":{"input_tokens":0,"output_tokens":0}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"I'm"}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" Kim"}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"i"}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":","}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" a"}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" large"}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" language"}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" model"}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" trained"}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" by"}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" Moon"}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"shot"}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" AI"}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"."}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":31,"output_tokens":15}}`,
+		`{"type":"message_stop"}`,
+	}, `{"id":"c91dda37dc3c4018ac0fecf81cf0052d","type":"message","role":"assistant","model":"Kimi-K2-Instruct","stop_reason":"end_turn","usage":{"input_tokens":31,"output_tokens":15},"content":[{"type":"text","text":"I'm Kimi, a large language model trained by Moonshot AI."}]}`)
+}
+
+func TestClaudeMerger_ToolCall(t *testing.T) {
+	runClaudeMerge(t, []string{
+		`{"type":"message_start","message":{"id":"1480f67c3ad545f580a0742339bb391b","type":"message","role":"assistant","content":[],"model":"Kimi-K2-Instruct","usage":{"input_tokens":0,"output_tokens":0}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"我来"}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"帮你"}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"查"}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"一下"}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"。"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"functions.search:0","name":"search","input":{}}}`,
+		`{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"queries"}}`,
+		`{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"\":"}}`,
+		`{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"1"}}`,
+		`{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"}"}}`,
+		`{"type":"content_block_stop","index":1}`,
+		`{"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"input_tokens":177,"output_tokens":69}}`,
+		`{"type":"message_stop"}`,
+	}, `{"id":"1480f67c3ad545f580a0742339bb391b","type":"message","role":"assistant","model":"Kimi-K2-Instruct","stop_reason":"tool_use","usage":{"input_tokens":177,"output_tokens":69},"content":[{"type":"text","text":"我来帮你查一下。"},{"type":"tool_use","id":"functions.search:0","name":"search","input":{"queries":1}}]}`)
+}
+
+func TestClaudeMerger_MultipleToolCall(t *testing.T) {
+	runClaudeMerge(t, []string{
+		`{"type":"message_start","message":{"id":"1480f67c3ad545f580a0742339bb391b","type":"message","role":"assistant","content":[],"model":"Kimi-K2-Instruct","usage":{"input_tokens":0,"output_tokens":0}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"我来"}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"帮你"}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"查"}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"一下"}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"。"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"functions.search:0","name":"search","input":{}}}`,
+		`{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"queries"}}`,
+		`{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"\":"}}`,
+		`{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"1"}}`,
+		`{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"}"}}`,
+		`{"type":"content_block_stop","index":1}`,
+		`{"type":"content_block_start","index":2,"content_block":{"type":"tool_use","id":"functions.fetch:1","name":"fetch","input":{}}}`,
+		`{"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"{\"queries"}}`,
+		`{"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"\":"}}`,
+		`{"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"2"}}`,
+		`{"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"}"}}`,
+		`{"type":"content_block_stop","index":2}`,
+		`{"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"input_tokens":177,"output_tokens":69}}`,
+		`{"type":"message_stop"}`,
+	}, `{"id":"1480f67c3ad545f580a0742339bb391b","type":"message","role":"assistant","model":"Kimi-K2-Instruct","stop_reason":"tool_use","usage":{"input_tokens":177,"output_tokens":69},"content":[{"type":"text","text":"我来帮你查一下。"},{"type":"tool_use","id":"functions.search:0","name":"search","input":{"queries":1}},{"type":"tool_use","id":"functions.fetch:1","name":"fetch","input":{"queries":2}}]}`)
+}
+
+// TestClaudeMerger_Sandwich interleaves tool_use, text, tool_use blocks to
+// confirm block order is preserved by index.
+func TestClaudeMerger_Sandwich(t *testing.T) {
+	runClaudeMerge(t, []string{
+		`{"type":"message_start","message":{"id":"1480f67c3ad545f580a0742339bb391b","type":"message","role":"assistant","content":[],"model":"Kimi-K2-Instruct","usage":{"input_tokens":0,"output_tokens":0}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"functions.search:0","name":"search","input":{}}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"queries"}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\":"}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"1"}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"}"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"我来"}}`,
+		`{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"帮你"}}`,
+		`{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"查"}}`,
+		`{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"一下"}}`,
+		`{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"。"}}`,
+		`{"type":"content_block_stop","index":1}`,
+		`{"type":"content_block_start","index":2,"content_block":{"type":"tool_use","id":"functions.fetch:1","name":"fetch","input":{}}}`,
+		`{"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"{\"queries"}}`,
+		`{"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"\":"}}`,
+		`{"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"2"}}`,
+		`{"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"}"}}`,
+		`{"type":"content_block_stop","index":2}`,
+		`{"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"input_tokens":177,"output_tokens":69}}`,
+		`{"type":"message_stop"}`,
+	}, `{"id":"1480f67c3ad545f580a0742339bb391b","type":"message","role":"assistant","model":"Kimi-K2-Instruct","stop_reason":"tool_use","usage":{"input_tokens":177,"output_tokens":69},"content":[{"type":"tool_use","id":"functions.search:0","name":"search","input":{"queries":1}},{"type":"text","text":"我来帮你查一下。"},{"type":"tool_use","id":"functions.fetch:1","name":"fetch","input":{"queries":2}}]}`)
+}
+
+func TestClaudeMerger_Reasoning(t *testing.T) {
+	runClaudeMerge(t, []string{
+		`{"type": "message_start", "message": {"id": "2026021010253871cb1b6ec9e54d6b", "type": "message", "role": "assistant", "model": "glm-4.6", "content": [], "usage": {"input_tokens": 0, "output_tokens": 0}}}`,
+		`{"type": "content_block_start", "index": 0, "content_block": {"type": "thinking", "thinking": "", "signature": ""}}`,
+		`{"type": "content_block_delta", "index": 0, "delta": {"type": "thinking_delta", "thinking": "\n"}}`,
+		`{"type": "content_block_delta", "index": 0, "delta": {"type": "thinking_delta", "thinking": "1"}}`,
+		`{"type": "content_block_delta", "index": 0, "delta": {"type": "thinking_delta", "thinking": "."}}`,
+		`{"type": "content_block_delta", "index": 0, "delta": {"type": "thinking_delta", "thinking": " "}}`,
+		`{"type": "content_block_delta", "index": 0, "delta": {"type": "thinking_delta", "thinking": " **"}}`,
+		`{"type": "content_block_delta", "index": 0, "delta": {"type": "thinking_delta", "thinking": "分析"}}`,
+		`{"type": "content_block_delta", "index": 0, "delta": {"type": "thinking_delta", "thinking": "用户的"}}`,
+		`{"type": "content_block_delta", "index": 0, "delta": {"type": "thinking_delta", "thinking": "查询"}}`,
+		`{"type": "content_block_delta", "index": 0, "delta": {"type": "thinking_delta", "thinking": "："}}`,
+		`{"type": "content_block_stop", "index": 0}`,
+		`{"type": "content_block_start", "index": 1, "content_block": {"type": "text", "text": ""}}`,
+		`{"type": "content_block_delta", "index": 1, "delta": {"type": "text_delta", "text": "\n"}}`,
+		`{"type": "content_block_delta", "index": 1, "delta": {"type": "text_delta", "text": "你好"}}`,
+		`{"type": "content_block_delta", "index": 1, "delta": {"type": "text_delta", "text": "！\n\n"}}`,
+		`{"type": "content_block_delta", "index": 1, "delta": {"type": "text_delta", "text": "我是一个"}}`,
+		`{"type": "content_block_delta", "index": 1, "delta": {"type": "text_delta", "text": "大型"}}`,
+		`{"type": "content_block_delta", "index": 1, "delta": {"type": "text_delta", "text": "语言"}}`,
+		`{"type": "content_block_delta", "index": 1, "delta": {"type": "text_delta", "text": "模型"}}`,
+		`{"type": "content_block_stop", "index": 1}`,
+		`{"type": "message_delta", "delta": {"stop_reason": "end_turn"}, "usage": {"input_tokens": 2, "output_tokens": 1024, "cache_read_input_tokens": 7}}`,
+		`{"type": "message_stop"}`,
+	}, `{"id":"2026021010253871cb1b6ec9e54d6b","type":"message","role":"assistant","model":"glm-4.6","stop_reason":"end_turn","usage":{"input_tokens":2,"output_tokens":1024,"cache_read_input_tokens":7},"content":[{"type":"thinking","thinking":"\n1.  **分析用户的查询：","signature":""},{"type":"text","text":"\n你好！\n\n我是一个大型语言模型"}]}`)
+}
+
+// TestClaudeMerger_EmptyToolInput verifies a tool_use that never receives an
+// input_json_delta defaults to a valid empty object rather than invalid JSON.
+func TestClaudeMerger_EmptyToolInput(t *testing.T) {
+	runClaudeMerge(t, []string{
+		`{"type":"message_start","message":{"id":"msg_3","type":"message","role":"assistant","model":"claude"}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_2","name":"noargs","input":{}}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_stop"}`,
+	}, `{"id":"msg_3","type":"message","role":"assistant","model":"claude","usage":null,"content":[{"type":"tool_use","id":"toolu_2","name":"noargs","input":{}}]}`)
+}
+
+// TestClaudeMerger_UsageSplit reflects real Anthropic streaming token accounting:
+// message_start carries input + cache counts (and output_tokens: 1), while
+// message_delta carries only the final output_tokens. The merged usage must keep
+// the input/cache counts from message_start and take output from message_delta —
+// a plain replace on message_delta (as maas-gateway does) would drop them.
+func TestClaudeMerger_UsageSplit(t *testing.T) {
+	runClaudeMerge(t, []string{
+		`{"type":"message_start","message":{"id":"msg_usage","type":"message","role":"assistant","model":"claude-sonnet-4","usage":{"input_tokens":25,"cache_creation_input_tokens":10,"cache_read_input_tokens":4,"output_tokens":1}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":15}}`,
+		`{"type":"message_stop"}`,
+	}, `{"id":"msg_usage","type":"message","role":"assistant","model":"claude-sonnet-4","stop_reason":"end_turn","usage":{"input_tokens":25,"output_tokens":15,"cache_creation_input_tokens":10,"cache_read_input_tokens":4},"content":[{"type":"text","text":"hi"}]}`)
+}

--- a/pkg/streammerge/merger.go
+++ b/pkg/streammerge/merger.go
@@ -1,0 +1,50 @@
+// Package streammerge accumulates the streamed SSE chunks of an LLM response
+// back into a single non-stream response body.
+//
+// It is the building block behind force-streaming (see
+// engines.NonStreamToStreamEngine): the gateway can always talk to the upstream
+// in streaming mode and, when the client asked for a non-stream response, fold
+// the chunks back into one JSON object. The same mergers are useful anywhere a
+// full response must be reconstructed from a stream (logging, moderation, token
+// accounting).
+//
+// Each Merger is single-use and NOT safe for concurrent use: feed every chunk
+// of one stream through Merge in order, then call Merged exactly once.
+package streammerge
+
+import (
+	"errors"
+
+	"github.com/infinigence/octollm/pkg/octollm"
+)
+
+// ErrUnsupportedFormat is returned by For when no merger is implemented for the
+// requested API format. Callers should treat it as "do not merge" rather than a
+// hard failure (e.g. pass the stream through untouched).
+var ErrUnsupportedFormat = errors.New("streammerge: no chunk merger for api format")
+
+// Merger folds the chunks of one streamed response into a single response body.
+type Merger interface {
+	// Merge accumulates a single stream chunk. The [octollm.ErrStreamDone]
+	// sentinel (the "[DONE]" terminator) is consumed silently.
+	Merge(*octollm.StreamChunk) error
+	// Merged returns the assembled non-stream response body. It may be called
+	// once after all chunks have been merged; further Merge calls are undefined.
+	Merged() (*octollm.UnifiedBody, error)
+}
+
+// For returns a fresh Merger for the given API format, or ErrUnsupportedFormat
+// if none is implemented. Adding a merger here automatically enables the
+// formats that depend on For (e.g. the force-stream engine).
+func For(format octollm.APIFormat) (Merger, error) {
+	switch format {
+	case octollm.APIFormatChatCompletions:
+		return NewChatCompletionMerger(), nil
+	case octollm.APIFormatClaudeMessages:
+		return NewClaudeMessagesMerger(), nil
+	default:
+		// Responses, Vertex generateContent, completions, etc. are not wired up
+		// yet. They fall through to ErrUnsupportedFormat on purpose.
+		return nil, ErrUnsupportedFormat
+	}
+}


### PR DESCRIPTION
* add pkg/streammerge: fold streamed SSE chunks back into a single response, with mergers for chat/completions and Claude messages and a For(format) factory
* add NonStreamToStreamEngine: force-stream merger-backed formats and merge the response, with WithEnabledFormats allowlist option
* add octollm.IsStreamRequest as the canonical protocol-aware stream detector; reuse it from the rule composer
* merge Claude usage across message_start/message_delta so input and cache token counts survive