### PR TITLE
fix: handle client cancel errors and add unwrapping

### DIFF
--- a/pkg/errutils/upstream_error.go
+++ b/pkg/errutils/upstream_error.go
@@ -29,6 +29,11 @@ func (e *UpstreamHTTPError) Error() string {
 	return fmt.Sprintf("upstream http error: status code %d, err %s", e.StatusCode, e.Err.Error())
 }
 
+// Unwrap returns the underlying error.
+func (e *UpstreamHTTPError) Unwrap() error {
+	return e.Err
+}
+
 // type UpstreamGeneralError struct {
 // 	Err error
 // }

--- a/pkg/octollm/handler.go
+++ b/pkg/octollm/handler.go
@@ -142,6 +142,10 @@ func httpSSEHandler(engine Engine, format APIFormat, parser Parser) http.Handler
 				*r = *errutils.WithHandlerError(r, handlerErr)
 				return
 			}
+			if errors.Is(err, context.Canceled) {
+				*r = *errutils.WithError(r, err, 499, "Client Closed Request")
+				return
+			}
 			*r = *errutils.WithError(r, err, http.StatusInternalServerError, "Internal Server Error")
 			return
 		}


### PR DESCRIPTION
Add Unwrap method for UpstreamHTTPError to support errors.Is with underlying error, and return 499 status code for client canceled requests instead of generic 500 internal server error