### PR TITLE
feat(usage): support cache write tokens and cache creation ttl breakdown

### DIFF
--- a/pkg/engines/converter/claude.go
+++ b/pkg/engines/converter/claude.go
@@ -755,11 +755,16 @@ func (e *ChatCompletionToClaudeMessages) sendEvent(ctx context.Context, ch chan<
 
 // convertUsage maps an OpenAI usage object onto Anthropic usage accounting.
 //
-// Anthropic reports cache reads separately from input tokens, so cached tokens are
-// subtracted out of prompt_tokens. cache_read_input_tokens is emitted whenever the
-// upstream reported prompt_tokens_details at all: an explicit zero is a real cache
-// accounting of "nothing hit the cache" and must survive the conversion, while an
-// absent prompt_tokens_details means the upstream reported no cache info to relay.
+// Anthropic reports cache reads and cache writes separately from input tokens, so
+// both are subtracted out of prompt_tokens. cache_read_input_tokens is emitted
+// whenever the upstream reported prompt_tokens_details at all: an explicit zero is
+// a real cache accounting of "nothing hit the cache" and must survive the
+// conversion, while an absent prompt_tokens_details means the upstream reported no
+// cache info to relay.
+//
+// cache_write_tokens maps onto the aggregate cache_creation_input_tokens only. The
+// OpenAI side carries no cache TTL, so the cache_creation 5m/1h breakdown is left
+// unset rather than guessed at.
 func convertUsage(u *openai.Usage) *anthropic.Usage {
 	if u == nil {
 		return nil
@@ -769,11 +774,23 @@ func convertUsage(u *openai.Usage) *anthropic.Usage {
 	if details != nil && details.CachedTokens != nil {
 		cached = int64(*details.CachedTokens)
 	}
+	var cacheWrite *int64
+	if details != nil && details.CacheWriteTokens != nil {
+		v := int64(*details.CacheWriteTokens)
+		cacheWrite = &v
+	}
+	// prompt_tokens is the grand total, so reads plus writes exceeding it would
+	// make input_tokens negative; clamp instead.
 	inputTokens := int64(u.PromptTokens) - cached
+	if cacheWrite != nil {
+		inputTokens -= *cacheWrite
+	}
+	inputTokens = max(inputTokens, 0)
 	outputTokens := int64(u.CompletionTokens)
 	usage := &anthropic.Usage{
-		InputTokens:  &inputTokens,
-		OutputTokens: &outputTokens,
+		InputTokens:              &inputTokens,
+		OutputTokens:             &outputTokens,
+		CacheCreationInputTokens: cacheWrite,
 	}
 	if details != nil {
 		usage.CacheReadInputTokens = &cached

--- a/pkg/engines/converter/claude_test.go
+++ b/pkg/engines/converter/claude_test.go
@@ -2173,6 +2173,165 @@ func TestChatCompletionsToClaudeMessages_convertStreamResponse_NoCachedTokens(t 
 	testChatCompletionsToClaudeMessages_convertStreamResponse(t, openaiRespJSON, expectedClaudeRespJSON)
 }
 
+// cache_write_tokens maps onto the aggregate cache_creation_input_tokens, and is
+// subtracted out of input_tokens along with the cache reads: prompt_tokens is the
+// grand total on the OpenAI side, whereas Anthropic's input_tokens counts only the
+// uncached remainder. The 5m/1h cache_creation breakdown must stay absent — the
+// OpenAI side carries no cache TTL to derive it from.
+func TestChatCompletionsToClaudeMessages_convertNonStreamResponseBody_CacheWriteTokens(t *testing.T) {
+	openaiRespJSON := `{
+		"id": "chatcmpl-123",
+		"object": "chat.completion",
+		"created": 1677652288,
+		"model": "gpt-4",
+		"choices": [{
+			"index": 0,
+			"message": {
+				"role": "assistant",
+				"content": "I'm doing well, thank you!"
+			},
+			"finish_reason": "stop"
+		}],
+		"usage": {
+			"prompt_tokens": 100,
+			"completion_tokens": 8,
+			"total_tokens": 108,
+			"prompt_tokens_details": {
+				"cached_tokens": 20,
+				"cache_write_tokens": 30
+			}
+		}
+	}`
+
+	expectedClaudeRespJSON := `{
+		"id": "chatcmpl-123",
+		"type": "message",
+		"role": "assistant",
+		"model": "gpt-4",
+		"content": [
+			{
+				"type": "text",
+				"text": "I'm doing well, thank you!"
+			}
+		],
+		"stop_reason": "end_turn",
+		"usage": {
+			"input_tokens": 50,
+			"output_tokens": 8,
+			"cache_read_input_tokens": 20,
+			"cache_creation_input_tokens": 30
+		}
+	}`
+
+	testChatCompletionsToClaudeMessages_convertNonStreamResponseBody(t, openaiRespJSON, expectedClaudeRespJSON)
+}
+
+// An explicit cache_write_tokens: 0 is a real accounting of "nothing was written to
+// the cache" and must survive as cache_creation_input_tokens: 0.
+func TestChatCompletionsToClaudeMessages_convertNonStreamResponseBody_ZeroCacheWriteTokens(t *testing.T) {
+	openaiRespJSON := `{
+		"id": "chatcmpl-123",
+		"object": "chat.completion",
+		"created": 1677652288,
+		"model": "gpt-4",
+		"choices": [{
+			"index": 0,
+			"message": {"role": "assistant", "content": "hi"},
+			"finish_reason": "stop"
+		}],
+		"usage": {
+			"prompt_tokens": 10,
+			"completion_tokens": 8,
+			"total_tokens": 18,
+			"prompt_tokens_details": {
+				"cached_tokens": 0,
+				"cache_write_tokens": 0
+			}
+		}
+	}`
+
+	expectedClaudeRespJSON := `{
+		"id": "chatcmpl-123",
+		"type": "message",
+		"role": "assistant",
+		"model": "gpt-4",
+		"content": [{"type": "text", "text": "hi"}],
+		"stop_reason": "end_turn",
+		"usage": {
+			"input_tokens": 10,
+			"output_tokens": 8,
+			"cache_read_input_tokens": 0,
+			"cache_creation_input_tokens": 0
+		}
+	}`
+
+	testChatCompletionsToClaudeMessages_convertNonStreamResponseBody(t, openaiRespJSON, expectedClaudeRespJSON)
+}
+
+// Upstreams that report reads plus writes exceeding prompt_tokens would otherwise
+// produce a negative input_tokens; it is clamped to 0 instead.
+func TestChatCompletionsToClaudeMessages_convertNonStreamResponseBody_CacheWriteExceedsPromptTokens(t *testing.T) {
+	openaiRespJSON := `{
+		"id": "chatcmpl-123",
+		"object": "chat.completion",
+		"created": 1677652288,
+		"model": "gpt-4",
+		"choices": [{
+			"index": 0,
+			"message": {"role": "assistant", "content": "hi"},
+			"finish_reason": "stop"
+		}],
+		"usage": {
+			"prompt_tokens": 10,
+			"completion_tokens": 8,
+			"total_tokens": 18,
+			"prompt_tokens_details": {
+				"cached_tokens": 6,
+				"cache_write_tokens": 30
+			}
+		}
+	}`
+
+	expectedClaudeRespJSON := `{
+		"id": "chatcmpl-123",
+		"type": "message",
+		"role": "assistant",
+		"model": "gpt-4",
+		"content": [{"type": "text", "text": "hi"}],
+		"stop_reason": "end_turn",
+		"usage": {
+			"input_tokens": 0,
+			"output_tokens": 8,
+			"cache_read_input_tokens": 6,
+			"cache_creation_input_tokens": 30
+		}
+	}`
+
+	testChatCompletionsToClaudeMessages_convertNonStreamResponseBody(t, openaiRespJSON, expectedClaudeRespJSON)
+}
+
+// Streaming variant of the cache_write_tokens mapping.
+func TestChatCompletionsToClaudeMessages_convertStreamResponse_CacheWriteTokens(t *testing.T) {
+	openaiRespJSON := []string{
+		`{"id":"chatcmpl-123","object":"chat.completion.chunk","created":1765734075,"model":"gpt-4","choices":[{"index":0,"delta":{"role":"assistant","content":"I'm","tool_calls":null},"logprobs":null,"finish_reason":null}]}`,
+		`{"id":"chatcmpl-123","object":"chat.completion.chunk","created":1765734075,"model":"gpt-4","choices":[{"index":0,"delta":{"content":" fine","tool_calls":null},"logprobs":null,"finish_reason":"stop","matched_stop":null}]}`,
+		`{"id":"chatcmpl-123","object":"chat.completion.chunk","created":1765734075,"model":"gpt-4","choices":[],"usage":{"prompt_tokens":100,"total_tokens":108,"completion_tokens":8,"prompt_tokens_details":{"cached_tokens":20,"cache_write_tokens":30}}}`,
+		`[DONE]`,
+	}
+
+	expectedClaudeRespJSON := []string{
+		`{"type":"message_start","message":{"id":"chatcmpl-123","type":"message","role":"assistant","content":[],"model":"gpt-4","usage":{"input_tokens":0,"output_tokens":0}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"I'm"}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" fine"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":50,"output_tokens":8,"cache_read_input_tokens":20,"cache_creation_input_tokens":30}}`,
+		`{"type":"message_stop"}`,
+	}
+
+	testChatCompletionsToClaudeMessages_convertStreamResponse(t, openaiRespJSON, expectedClaudeRespJSON)
+}
+
 // A non-thinking response that carries reasoning_content: null must not produce an
 // empty thinking block. Currently reasoning_content: null parses to a non-nil empty
 // MessageContentString, so the converter emits a thinking block with thinking: "";

--- a/pkg/streammerge/chatcompletion.go
+++ b/pkg/streammerge/chatcompletion.go
@@ -128,8 +128,10 @@ func mergeChatCompletionUsage(dst, src *openai.Usage) *openai.Usage {
 		return dst
 	}
 	if dst == nil {
-		cp := *src
-		return &cp
+		// Start from a fresh object rather than copying src wholesale: a shallow
+		// copy would share the nested details structs with the chunk, so merging
+		// a later chunk would mutate the earlier chunk's parsed body.
+		dst = &openai.Usage{}
 	}
 	if src.CompletionTokens != 0 {
 		dst.CompletionTokens = src.CompletionTokens
@@ -181,6 +183,9 @@ func mergePromptTokensDetails(dst, src *openai.PromptTokensDetails) *openai.Prom
 	}
 	if src.AudioTokens != nil {
 		dst.AudioTokens = src.AudioTokens
+	}
+	if src.CacheWriteTokens != nil {
+		dst.CacheWriteTokens = src.CacheWriteTokens
 	}
 	return dst
 }

--- a/pkg/streammerge/chatcompletion_test.go
+++ b/pkg/streammerge/chatcompletion_test.go
@@ -160,3 +160,25 @@ func TestChatCompletionMerger_UsagePromptTokensDetailsAbsent(t *testing.T) {
 		`[DONE]`,
 	}, `{"id":"x","created":1,"object":"chat.completion","model":"m","usage":{"completion_tokens":8,"prompt_tokens":10,"total_tokens":18},"choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","content":"hi"}}]}`)
 }
+
+// cache_write_tokens on the final usage chunk must reach the merged usage.
+func TestChatCompletionMerger_UsageCacheWriteTokens(t *testing.T) {
+	runChatMerge(t, []string{
+		`{"id":"x","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"role":"assistant","content":"hi"}}]}`,
+		`{"id":"x","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"finish_reason":"stop","delta":{"content":""}}]}`,
+		`{"id":"x","object":"chat.completion.chunk","created":1,"model":"m","choices":[],"usage":{"prompt_tokens":100,"total_tokens":150,"completion_tokens":50,"prompt_tokens_details":{"cached_tokens":10,"cache_write_tokens":40}}}`,
+		`[DONE]`,
+	}, `{"id":"x","created":1,"object":"chat.completion","model":"m","usage":{"completion_tokens":50,"prompt_tokens":100,"total_tokens":150,"prompt_tokens_details":{"cached_tokens":10,"cache_write_tokens":40}},"choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","content":"hi"}}]}`)
+}
+
+// cache_write_tokens and cached_tokens arriving on separate usage chunks must
+// both survive into the merged usage instead of the later chunk clobbering the
+// earlier one.
+func TestChatCompletionMerger_UsageCacheWriteSplitAcrossChunks(t *testing.T) {
+	runChatMerge(t, []string{
+		`{"id":"x","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"role":"assistant","content":"hi"}}],"usage":{"prompt_tokens":0,"total_tokens":0,"completion_tokens":0,"prompt_tokens_details":{"cache_write_tokens":40}}}`,
+		`{"id":"x","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"finish_reason":"stop","delta":{"content":""}}]}`,
+		`{"id":"x","object":"chat.completion.chunk","created":1,"model":"m","choices":[],"usage":{"prompt_tokens":100,"total_tokens":150,"completion_tokens":50,"prompt_tokens_details":{"cached_tokens":10}}}`,
+		`[DONE]`,
+	}, `{"id":"x","created":1,"object":"chat.completion","model":"m","usage":{"completion_tokens":50,"prompt_tokens":100,"total_tokens":150,"prompt_tokens_details":{"cached_tokens":10,"cache_write_tokens":40}},"choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","content":"hi"}}]}`)
+}

--- a/pkg/streammerge/claude.go
+++ b/pkg/streammerge/claude.go
@@ -184,8 +184,10 @@ func mergeClaudeUsage(dst, src *anthropic.Usage) *anthropic.Usage {
 		return dst
 	}
 	if dst == nil {
-		cp := *src
-		return &cp
+		// Start from a fresh object rather than copying src wholesale: a shallow
+		// copy would share the nested CacheCreation with the event, so merging a
+		// later event would mutate the earlier event's parsed body.
+		dst = &anthropic.Usage{}
 	}
 	if src.InputTokens != nil {
 		dst.InputTokens = src.InputTokens
@@ -198,6 +200,28 @@ func mergeClaudeUsage(dst, src *anthropic.Usage) *anthropic.Usage {
 	}
 	if src.CacheReadInputTokens != nil {
 		dst.CacheReadInputTokens = src.CacheReadInputTokens
+	}
+	dst.CacheCreation = mergeClaudeCacheCreation(dst.CacheCreation, src.CacheCreation)
+	return dst
+}
+
+// mergeClaudeCacheCreation overlays the non-nil TTL buckets from src onto dst.
+// message_delta may repeat cache_creation with only one bucket populated (the
+// other explicitly null), so merging per field keeps the value message_start
+// reported instead of dropping it.
+func mergeClaudeCacheCreation(dst, src *anthropic.CacheCreation) *anthropic.CacheCreation {
+	if src == nil {
+		return dst
+	}
+	if dst == nil {
+		cp := *src
+		return &cp
+	}
+	if src.Ephemeral5mInputTokens != nil {
+		dst.Ephemeral5mInputTokens = src.Ephemeral5mInputTokens
+	}
+	if src.Ephemeral1hInputTokens != nil {
+		dst.Ephemeral1hInputTokens = src.Ephemeral1hInputTokens
 	}
 	return dst
 }

--- a/pkg/streammerge/claude_test.go
+++ b/pkg/streammerge/claude_test.go
@@ -187,3 +187,43 @@ func TestClaudeMerger_UsageSplit(t *testing.T) {
 		`{"type":"message_stop"}`,
 	}, `{"id":"msg_usage","type":"message","role":"assistant","model":"claude-sonnet-4","stop_reason":"end_turn","usage":{"input_tokens":25,"output_tokens":15,"cache_creation_input_tokens":10,"cache_read_input_tokens":4},"content":[{"type":"text","text":"hi"}]}`)
 }
+
+// TestClaudeMerger_CacheCreationSplit checks the 5m/1h breakdown announced in
+// message_start survives into the merged usage.
+func TestClaudeMerger_CacheCreationSplit(t *testing.T) {
+	runClaudeMerge(t, []string{
+		`{"type":"message_start","message":{"id":"msg_split","type":"message","role":"assistant","model":"claude-sonnet-4","usage":{"input_tokens":2,"cache_creation_input_tokens":2573,"cache_read_input_tokens":194664,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":2573},"output_tokens":1}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":15}}`,
+		`{"type":"message_stop"}`,
+	}, `{"id":"msg_split","type":"message","role":"assistant","model":"claude-sonnet-4","stop_reason":"end_turn","usage":{"input_tokens":2,"output_tokens":15,"cache_creation_input_tokens":2573,"cache_read_input_tokens":194664,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":2573}},"content":[{"type":"text","text":"hi"}]}`)
+}
+
+// TestClaudeMerger_CacheCreationPartialRepeat covers message_delta repeating
+// cache_creation with one bucket explicitly null: the null must not erase the
+// value message_start reported for that bucket.
+func TestClaudeMerger_CacheCreationPartialRepeat(t *testing.T) {
+	runClaudeMerge(t, []string{
+		`{"type":"message_start","message":{"id":"msg_partial","type":"message","role":"assistant","model":"claude-sonnet-4","usage":{"input_tokens":10,"cache_creation_input_tokens":42,"cache_creation":{"ephemeral_5m_input_tokens":40,"ephemeral_1h_input_tokens":2},"output_tokens":1}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":15,"cache_creation_input_tokens":42,"cache_creation":{"ephemeral_5m_input_tokens":null}}}`,
+		`{"type":"message_stop"}`,
+	}, `{"id":"msg_partial","type":"message","role":"assistant","model":"claude-sonnet-4","stop_reason":"end_turn","usage":{"input_tokens":10,"output_tokens":15,"cache_creation_input_tokens":42,"cache_creation":{"ephemeral_5m_input_tokens":40,"ephemeral_1h_input_tokens":2}},"content":[{"type":"text","text":"hi"}]}`)
+}
+
+// TestClaudeMerger_CacheCreationOnlyInMessageDelta covers cache_creation arriving
+// first on message_delta, with no cache_creation in message_start to merge onto.
+func TestClaudeMerger_CacheCreationOnlyInMessageDelta(t *testing.T) {
+	runClaudeMerge(t, []string{
+		`{"type":"message_start","message":{"id":"msg_late","type":"message","role":"assistant","model":"claude-sonnet-4","usage":{"input_tokens":10,"output_tokens":1}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":20,"cache_creation":{"ephemeral_5m_input_tokens":100,"ephemeral_1h_input_tokens":0}}}`,
+		`{"type":"message_stop"}`,
+	}, `{"id":"msg_late","type":"message","role":"assistant","model":"claude-sonnet-4","stop_reason":"end_turn","usage":{"input_tokens":10,"output_tokens":20,"cache_creation":{"ephemeral_5m_input_tokens":100,"ephemeral_1h_input_tokens":0}},"content":[{"type":"text","text":"hi"}]}`)
+}

--- a/pkg/types/anthropic/messages_response.go
+++ b/pkg/types/anthropic/messages_response.go
@@ -35,6 +35,21 @@ type Usage struct {
 
 	// Tokens from cache read (prompt caching)
 	CacheReadInputTokens *int64 `json:"cache_read_input_tokens,omitempty"`
+
+	// Breakdown of CacheCreationInputTokens by cache TTL. Only sent by models
+	// that support the extended (1h) cache; when present the two entries sum to
+	// cache_creation_input_tokens.
+	CacheCreation *CacheCreation `json:"cache_creation,omitempty"`
+}
+
+// CacheCreation splits cache-creation input tokens by the TTL of the cache
+// entry they were written to.
+type CacheCreation struct {
+	// Tokens written to a 5-minute (default) ephemeral cache entry
+	Ephemeral5mInputTokens *int64 `json:"ephemeral_5m_input_tokens,omitempty"`
+
+	// Tokens written to a 1-hour ephemeral cache entry
+	Ephemeral1hInputTokens *int64 `json:"ephemeral_1h_input_tokens,omitempty"`
 }
 
 // ClaudeMessagesStreamEvent represents a streaming event

--- a/pkg/types/anthropic/messages_response_jlexer.go
+++ b/pkg/types/anthropic/messages_response_jlexer.go
@@ -3,7 +3,7 @@
 // This file contains jlexer streaming parsers for the structs defined in:
 //   pkg/types/anthropic/messages_response.go
 //
-// Source file SHA-256: 412cb28ff80bf6d58fffaadfed7ca17c942609ecda640835bd257ebc373144f5
+// Source file SHA-256: afcce67c22f5cae5706f1bc2a1561065a31de49ccc3442e6b60f8e613a510ce9
 //
 // Generation guide: pkg/types/JLEXER_PARSER_GUIDE.md
 // Polymorphic field patterns: pkg/types/UNION_TYPES.md
@@ -141,6 +141,55 @@ func (u *Usage) ParseJLexer(in *jlexer.Lexer) {
 			} else {
 				v := in.Int64()
 				u.CacheReadInputTokens = &v
+			}
+		case "cache_creation":
+			if in.IsNull() {
+				in.Skip()
+				u.CacheCreation = nil
+			} else {
+				u.CacheCreation = &CacheCreation{}
+				u.CacheCreation.ParseJLexer(in)
+			}
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+
+func (c *CacheCreation) ParseJLexer(in *jlexer.Lexer) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		switch key {
+		case "ephemeral_5m_input_tokens":
+			if in.IsNull() {
+				in.Skip()
+				c.Ephemeral5mInputTokens = nil
+			} else {
+				v := in.Int64()
+				c.Ephemeral5mInputTokens = &v
+			}
+		case "ephemeral_1h_input_tokens":
+			if in.IsNull() {
+				in.Skip()
+				c.Ephemeral1hInputTokens = nil
+			} else {
+				v := in.Int64()
+				c.Ephemeral1hInputTokens = &v
 			}
 		default:
 			in.SkipRecursive()

--- a/pkg/types/anthropic/messages_response_jlexer_test.go
+++ b/pkg/types/anthropic/messages_response_jlexer_test.go
@@ -128,6 +128,26 @@ func TestClaudeMessagesResponse_ParseJLexer(t *testing.T) {
 			JSON: `{"id":"msg_11","type":"message","role":"assistant","model":"claude-3-5-sonnet","content":[],"usage":{"input_tokens":5,"cache_read_input_tokens":2}}`,
 		},
 		{
+			Name: "UsageWithCacheCreationSplit",
+			JSON: `{"id":"msg_14","type":"message","role":"assistant","model":"claude-3-5-sonnet","content":[],"usage":{"input_tokens":5,"cache_creation_input_tokens":30,"cache_creation":{"ephemeral_5m_input_tokens":10,"ephemeral_1h_input_tokens":20}}}`,
+		},
+		{
+			Name: "UsageWithNullCacheCreation",
+			JSON: `{"id":"msg_15","type":"message","role":"assistant","model":"claude-3-5-sonnet","content":[],"usage":{"input_tokens":5,"cache_creation":null}}`,
+		},
+		{
+			Name: "UsageWithEmptyCacheCreation",
+			JSON: `{"id":"msg_16","type":"message","role":"assistant","model":"claude-3-5-sonnet","content":[],"usage":{"input_tokens":5,"cache_creation":{}}}`,
+		},
+		{
+			Name: "UsageWithPartialCacheCreation",
+			JSON: `{"id":"msg_17","type":"message","role":"assistant","model":"claude-3-5-sonnet","content":[],"usage":{"input_tokens":5,"cache_creation":{"ephemeral_5m_input_tokens":10,"ephemeral_1h_input_tokens":null}}}`,
+		},
+		{
+			Name: "UsageWithUnknownCacheCreationBucket",
+			JSON: `{"id":"msg_18","type":"message","role":"assistant","model":"claude-3-5-sonnet","content":[],"usage":{"input_tokens":5,"cache_creation":{"ephemeral_24h_input_tokens":7,"ephemeral_5m_input_tokens":10}}}`,
+		},
+		{
 			Name: "TopLevelNull",
 			JSON: `null`,
 		},
@@ -264,6 +284,14 @@ func TestClaudeMessagesStreamEvent_ParseJLexer(t *testing.T) {
 		{
 			Name: "ClaudeSonnet46_MessageDelta",
 			JSON: `{"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null,"stop_details":null},"usage":{"input_tokens":680,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":38}}`,
+		},
+		{
+			Name: "MessageStart_CacheCreationSplit",
+			JSON: `{"type":"message_start","message":{"id":"msg_split","type":"message","role":"assistant","model":"claude-sonnet-4","content":[],"usage":{"input_tokens":2,"output_tokens":1,"cache_creation_input_tokens":2573,"cache_read_input_tokens":194664,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":2573}}}}`,
+		},
+		{
+			Name: "MessageDelta_CacheCreationPartialNull",
+			JSON: `{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":15,"cache_creation_input_tokens":42,"cache_creation":{"ephemeral_5m_input_tokens":null}}}`,
 		},
 		{
 			Name: "ClaudeSonnet46_MessageStop",

--- a/pkg/types/anthropic/messages_response_test.go
+++ b/pkg/types/anthropic/messages_response_test.go
@@ -101,8 +101,8 @@ func TestClaudeMessagesStreamEvent_Marshal_UnmarshalJSON(t *testing.T) {
 
 // TestRealAPI_NonStreamResponses_Unmarshal tests unmarshaling of real non-streaming API
 // responses captured from Infini-AI's GLM-5.1 and Claude-Sonnet-4-6 models. These responses
-// contain extra non-standard fields (e.g. prompt_tokens_details, caller, stop_details,
-// cache_creation) that our types don't model, so only Unmarshal is tested.
+// contain extra non-standard fields (e.g. prompt_tokens_details, caller, stop_details)
+// that our types don't model, so only Unmarshal is tested.
 func TestRealAPI_NonStreamResponses_Unmarshal(t *testing.T) {
 	testCases := []struct {
 		Name   string
@@ -258,6 +258,10 @@ func TestRealAPI_NonStreamResponses_Unmarshal(t *testing.T) {
 					OutputTokens:             int64Ptr(71),
 					CacheCreationInputTokens: int64Ptr(0),
 					CacheReadInputTokens:     int64Ptr(0),
+					CacheCreation: &CacheCreation{
+						Ephemeral5mInputTokens: int64Ptr(0),
+						Ephemeral1hInputTokens: int64Ptr(0),
+					},
 				},
 			},
 		},
@@ -432,6 +436,10 @@ func TestRealAPI_StreamEvents_Unmarshal(t *testing.T) {
 						OutputTokens:             int64Ptr(5),
 						CacheCreationInputTokens: int64Ptr(0),
 						CacheReadInputTokens:     int64Ptr(0),
+						CacheCreation: &CacheCreation{
+							Ephemeral5mInputTokens: int64Ptr(0),
+							Ephemeral1hInputTokens: int64Ptr(0),
+						},
 					},
 				},
 			},

--- a/pkg/types/anthropic/stringer.go
+++ b/pkg/types/anthropic/stringer.go
@@ -173,6 +173,14 @@ func (r ClaudeMessagesResponse) String() string {
 		if u.CacheReadInputTokens != nil {
 			fmt.Fprintf(w, ", cache_read=%d", *u.CacheReadInputTokens)
 		}
+		if c := u.CacheCreation; c != nil {
+			if c.Ephemeral5mInputTokens != nil {
+				fmt.Fprintf(w, ", cache_creation_5m=%d", *c.Ephemeral5mInputTokens)
+			}
+			if c.Ephemeral1hInputTokens != nil {
+				fmt.Fprintf(w, ", cache_creation_1h=%d", *c.Ephemeral1hInputTokens)
+			}
+		}
 		w.WriteString("\n")
 	}
 	return fmt.Sprintf("(ClaudeMessagesResponse) {\n%s}", w.String())

--- a/pkg/types/anthropic/stringer_test.go
+++ b/pkg/types/anthropic/stringer_test.go
@@ -236,6 +236,34 @@ func TestClaudeMessagesResponse_String(t *testing.T) {
   Usage: input=7, output=4, cache_creation=2
 }`,
 		},
+		{
+			name: "usage with cache_creation ttl breakdown",
+			json: `{
+				"id": "msg_04",
+				"type": "message",
+				"role": "assistant",
+				"model": "claude-3-5-sonnet-20241022",
+				"content": [{"type": "text", "text": "ok"}],
+				"stop_reason": "end_turn",
+				"usage": {
+					"input_tokens": 2,
+					"output_tokens": 3,
+					"cache_creation_input_tokens": 2573,
+					"cache_read_input_tokens": 194664,
+					"cache_creation": {"ephemeral_5m_input_tokens": 0, "ephemeral_1h_input_tokens": 2573}
+				}
+			}`,
+			expected: `(ClaudeMessagesResponse) {
+  ID: "msg_04"
+  Type: "message"
+  Role: "assistant"
+  Model: "claude-3-5-sonnet-20241022"
+  Content: len(1)
+    text(len=2)
+  StopReason: end_turn
+  Usage: input=2, output=3, cache_creation=2573, cache_read=194664, cache_creation_5m=0, cache_creation_1h=2573
+}`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/types/openai/chatcompletion_resp.go
+++ b/pkg/types/openai/chatcompletion_resp.go
@@ -63,4 +63,8 @@ type CompletionTokensDetails struct {
 type PromptTokensDetails struct {
 	CachedTokens *int `json:"cached_tokens,omitempty"` // 缓存命中的 tokens
 	AudioTokens  *int `json:"audio_tokens,omitempty"`  // 音频输入使用的 tokens
+
+	// CacheWriteTokens is the prompt-caching write count: tokens that were
+	// written into the cache by this request rather than read from it.
+	CacheWriteTokens *int `json:"cache_write_tokens,omitempty"`
 }

--- a/pkg/types/openai/chatcompletion_resp_jlexer.go
+++ b/pkg/types/openai/chatcompletion_resp_jlexer.go
@@ -3,7 +3,7 @@
 // This file contains jlexer streaming parsers for the structs defined in:
 //   pkg/types/openai/chatcompletion_resp.go
 //
-// Source file SHA-256: 0dbc868f1b484d4913987ce9e19575777063939d5df571b57bd940bcc0a57fb2
+// Source file SHA-256: b631d369a27cde452655c8f5fe3a9d81455461a541b270ad35230b071e11d66b
 //
 // Generation guide: pkg/types/JLEXER_PARSER_GUIDE.md
 // Polymorphic field patterns: pkg/types/UNION_TYPES.md
@@ -409,6 +409,14 @@ func (d *PromptTokensDetails) ParseJLexer(in *jlexer.Lexer) {
 			} else {
 				v := in.Int()
 				d.AudioTokens = &v
+			}
+		case "cache_write_tokens":
+			if in.IsNull() {
+				in.Skip()
+				d.CacheWriteTokens = nil
+			} else {
+				v := in.Int()
+				d.CacheWriteTokens = &v
 			}
 		default:
 			in.SkipRecursive()

--- a/pkg/types/openai/chatcompletion_resp_jlexer_test.go
+++ b/pkg/types/openai/chatcompletion_resp_jlexer_test.go
@@ -83,6 +83,22 @@ func TestChatCompletionResponse_ParseJLexer(t *testing.T) {
 			JSON: `{"id":"chatcmpl-1","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15,"prompt_tokens_details":{"cached_tokens":5,"audio_tokens":2}}}`,
 		},
 		{
+			Name: "response with cache_write_tokens",
+			JSON: `{"id":"chatcmpl-1","choices":[],"usage":{"prompt_tokens":100,"completion_tokens":5,"total_tokens":105,"prompt_tokens_details":{"cached_tokens":20,"cache_write_tokens":30}}}`,
+		},
+		{
+			Name: "response with zero cache_write_tokens",
+			JSON: `{"id":"chatcmpl-1","choices":[],"usage":{"prompt_tokens":100,"completion_tokens":5,"total_tokens":105,"prompt_tokens_details":{"cached_tokens":0,"cache_write_tokens":0}}}`,
+		},
+		{
+			Name: "response with null cache_write_tokens",
+			JSON: `{"id":"chatcmpl-1","choices":[],"usage":{"prompt_tokens":100,"completion_tokens":5,"total_tokens":105,"prompt_tokens_details":{"cached_tokens":20,"cache_write_tokens":null}}}`,
+		},
+		{
+			Name: "response with cache_write_tokens only",
+			JSON: `{"id":"chatcmpl-1","choices":[],"usage":{"prompt_tokens":100,"completion_tokens":5,"total_tokens":105,"prompt_tokens_details":{"cache_write_tokens":30}}}`,
+		},
+		{
 			Name: "top-level null response",
 			JSON: `null`,
 		},
@@ -143,6 +159,14 @@ func TestChatCompletionStreamChunk_ParseJLexer(t *testing.T) {
 		{
 			Name: "FinalChunk_WithUsageDetails",
 			JSON: `{"id":"chatcmpl-123","object":"chat.completion.chunk","created":1694268190,"model":"gpt-4","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":100,"completion_tokens":50,"total_tokens":150,"completion_tokens_details":{"reasoning_tokens":20,"audio_tokens":5},"prompt_tokens_details":{"cached_tokens":10,"audio_tokens":2}}}`,
+		},
+		{
+			Name: "FinalChunk_WithCacheWriteTokens",
+			JSON: `{"id":"chatcmpl-123","object":"chat.completion.chunk","created":1694268190,"model":"gpt-4","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":100,"completion_tokens":50,"total_tokens":150,"prompt_tokens_details":{"cached_tokens":10,"cache_write_tokens":40}}}`,
+		},
+		{
+			Name: "FinalChunk_WithNullCacheWriteTokens",
+			JSON: `{"id":"chatcmpl-123","object":"chat.completion.chunk","created":1694268190,"model":"gpt-4","choices":[],"usage":{"prompt_tokens":100,"completion_tokens":50,"total_tokens":150,"prompt_tokens_details":{"cached_tokens":10,"cache_write_tokens":null}}}`,
 		},
 		{
 			Name: "ReasoningContent_String",

--- a/pkg/types/openai/responses_req_test.go
+++ b/pkg/types/openai/responses_req_test.go
@@ -271,8 +271,26 @@ func TestResponsesResponse_UnmarshalJSON(t *testing.T) {
 					InputTokens:         10,
 					OutputTokens:        5,
 					TotalTokens:         15,
-					InputTokensDetails:  &ResponsesInputTokenDetails{CachedTokens: 3},
-					OutputTokensDetails: &ResponsesOutputTokenDetails{ReasoningTokens: 2},
+					InputTokensDetails:  &ResponsesInputTokenDetails{CachedTokens: intPtr(3)},
+					OutputTokensDetails: &ResponsesOutputTokenDetails{ReasoningTokens: intPtr(2)},
+				},
+			},
+		},
+		{
+			Name: "UsageWithCacheWriteTokens",
+			JSON: `{
+				"id":"r2","object":"response","created_at":1,"status":"completed","model":"m",
+				"usage":{"input_tokens":100,"output_tokens":5,"total_tokens":105,
+					"input_tokens_details":{"cached_tokens":20,"cache_write_tokens":30}
+				}
+			}`,
+			Object: ResponsesResponse{
+				Id: "r2",
+				Usage: &ResponsesUsage{
+					InputTokens:        100,
+					OutputTokens:       5,
+					TotalTokens:        105,
+					InputTokensDetails: &ResponsesInputTokenDetails{CachedTokens: intPtr(20), CacheWriteTokens: intPtr(30)},
 				},
 			},
 		},

--- a/pkg/types/openai/responses_resp.go
+++ b/pkg/types/openai/responses_resp.go
@@ -64,13 +64,21 @@ type ResponsesUsage struct {
 }
 
 // ResponsesInputTokenDetails breaks down input tokens (e.g. prompt caching).
+//
+// The counts are pointers so an upstream that omits one is distinguishable from
+// one reporting an explicit zero, matching PromptTokensDetails on the
+// chat/completions side.
 type ResponsesInputTokenDetails struct {
-	CachedTokens int `json:"cached_tokens"`
+	CachedTokens *int `json:"cached_tokens,omitempty"`
+
+	// CacheWriteTokens is the prompt-caching write count: tokens that were
+	// written into the cache by this request rather than read from it.
+	CacheWriteTokens *int `json:"cache_write_tokens,omitempty"`
 }
 
 // ResponsesOutputTokenDetails breaks down output tokens (e.g. reasoning).
 type ResponsesOutputTokenDetails struct {
-	ReasoningTokens int `json:"reasoning_tokens"`
+	ReasoningTokens *int `json:"reasoning_tokens,omitempty"`
 }
 
 // ResponseStreamChunk is one SSE JSON object from POST /v1/responses with stream=true.

--- a/pkg/types/openai/stringer.go
+++ b/pkg/types/openai/stringer.go
@@ -239,6 +239,9 @@ func usageString(u *Usage) string {
 		if d.CachedTokens != nil && *d.CachedTokens > 0 {
 			fmt.Fprintf(w, ", cached=%d", *d.CachedTokens)
 		}
+		if d.CacheWriteTokens != nil && *d.CacheWriteTokens > 0 {
+			fmt.Fprintf(w, ", cache_write=%d", *d.CacheWriteTokens)
+		}
 		if d.AudioTokens != nil && *d.AudioTokens > 0 {
 			fmt.Fprintf(w, ", prompt_audio=%d", *d.AudioTokens)
 		}
@@ -363,11 +366,16 @@ func (r ResponsesResponse) String() string {
 	}
 	if u := r.Usage; u != nil {
 		fmt.Fprintf(w, "  Usage: input=%d, output=%d, total=%d", u.InputTokens, u.OutputTokens, u.TotalTokens)
-		if d := u.InputTokensDetails; d != nil && d.CachedTokens > 0 {
-			fmt.Fprintf(w, ", cached=%d", d.CachedTokens)
+		if d := u.InputTokensDetails; d != nil {
+			if d.CachedTokens != nil && *d.CachedTokens > 0 {
+				fmt.Fprintf(w, ", cached=%d", *d.CachedTokens)
+			}
+			if d.CacheWriteTokens != nil && *d.CacheWriteTokens > 0 {
+				fmt.Fprintf(w, ", cache_write=%d", *d.CacheWriteTokens)
+			}
 		}
-		if d := u.OutputTokensDetails; d != nil && d.ReasoningTokens > 0 {
-			fmt.Fprintf(w, ", reasoning=%d", d.ReasoningTokens)
+		if d := u.OutputTokensDetails; d != nil && d.ReasoningTokens != nil && *d.ReasoningTokens > 0 {
+			fmt.Fprintf(w, ", reasoning=%d", *d.ReasoningTokens)
 		}
 		w.WriteString("\n")
 	}

--- a/pkg/types/openai/stringer_test.go
+++ b/pkg/types/openai/stringer_test.go
@@ -413,6 +413,35 @@ func TestChatCompletionResponse_String(t *testing.T) {
   ServiceTier: "default"
 }`,
 		},
+		{
+			name: "usage with cache_write_tokens",
+			json: `{
+				"id": "chatcmpl-789",
+				"object": "chat.completion",
+				"created": 1700000002,
+				"model": "gpt-4",
+				"choices": [{
+					"index": 0,
+					"message": {"role": "assistant", "content": "ok"},
+					"finish_reason": "stop"
+				}],
+				"usage": {
+					"prompt_tokens": 100,
+					"completion_tokens": 5,
+					"total_tokens": 105,
+					"prompt_tokens_details": {"cached_tokens": 20, "cache_write_tokens": 30}
+				}
+			}`,
+			expected: `(ChatCompletionResponse) {
+  ID: "chatcmpl-789"
+  Model: "gpt-4"
+  Object: "chat.completion"
+  Created: 1700000002
+  Choices: len(1)
+    Choice{index=0, finish_reason=stop, message=(Message) {Role: "assistant", Content: len(2), }}
+  Usage: prompt=100, completion=5, total=105, cached=20, cache_write=30
+}`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -583,6 +612,24 @@ func TestResponsesResponse_String(t *testing.T) {
   ID: "resp_2"
   Output: len(0)
   Usage: input=1, output=2, total=3
+}`,
+		},
+		{
+			name: "usage with cache_write_tokens",
+			json: `{
+				"id": "resp_3",
+				"output": [],
+				"usage": {
+					"input_tokens": 100,
+					"output_tokens": 5,
+					"total_tokens": 105,
+					"input_tokens_details": {"cached_tokens": 20, "cache_write_tokens": 30}
+				}
+			}`,
+			expected: `(ResponsesResponse) {
+  ID: "resp_3"
+  Output: len(0)
+  Usage: input=100, output=5, total=105, cached=20, cache_write=30
 }`,
 		},
 	}


### PR DESCRIPTION
* add cache_write_tokens to OpenAI PromptTokensDetails and ResponsesInputTokenDetails
* add the cache_creation 5m/1h breakdown to Anthropic messages Usage
* fold the new fields per-field in the chat/completions and claude stream mergers
* map cache_write_tokens onto cache_creation_input_tokens in the claude converter, subtracting it from input_tokens and clamping at zero
* stop both mergers aliasing a chunk's nested usage structs when the accumulator is empty