### PR TITLE
Only prioritize strong cache-hit backends in shard-key WRR.

### DIFF
--- a/pkg/engines/load-balancer/shard_key_round_robin.go
+++ b/pkg/engines/load-balancer/shard_key_round_robin.go
@@ -79,8 +79,8 @@ func NewShardKeyWeightedRoundRobin(
 	}, nil
 }
 
-// resolveAffinity maps provider candidates to the existing WRR backends so currentWeight state
-// remains shared across requests.
+// resolveAffinity maps strong-cache-hit provider candidates to the existing WRR backends so
+// currentWeight state remains shared across requests. Weak hits fall through to normal WRR.
 func (l *ShardKeyWeightedRoundRobin) resolveAffinity(req *octollm.Request) ([]*wrrBackend, AffinityCommitFunc, error) {
 	if l.affinityProvider == nil {
 		return nil, nil, nil
@@ -100,7 +100,7 @@ func (l *ShardKeyWeightedRoundRobin) resolveAffinity(req *octollm.Request) ([]*w
 
 	prioritized := make([]*wrrBackend, 0, len(providerBackends))
 	for _, pb := range providerBackends {
-		if pb == nil {
+		if pb == nil || !pb.StrongCacheHit {
 			continue
 		}
 		backend, ok := backendByName[pb.Name]

--- a/pkg/engines/load-balancer/shard_key_round_robin_test.go
+++ b/pkg/engines/load-balancer/shard_key_round_robin_test.go
@@ -158,6 +158,50 @@ func TestResolveAffinity_WithRedisAndTrim(t *testing.T) {
 	assert.LessOrEqual(t, card, int64(3))
 }
 
+func TestResolveAffinity_OnlyStrongCacheHits(t *testing.T) {
+	mr := miniredis.RunT(t)
+	defer mr.Close()
+
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+
+	backends := []BackendItem{
+		{Name: "weak"},
+		{Name: "strong"},
+	}
+	provider := newPrimaryShardKeyProvider(
+		t,
+		func(_ *octollm.Request) []string { return []string{"k1", "k2", "k3"} },
+		client,
+		"",
+		5*time.Minute,
+		backends,
+	)
+	lb, err := NewShardKeyWeightedRoundRobin(backends, 5*time.Second, 5, provider, nil)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	now := float64(time.Now().Unix())
+
+	t.Run("weak hit on first key is not prioritized", func(t *testing.T) {
+		_, zerr := client.ZAdd(ctx, "k1", redis.Z{Score: now, Member: "weak"}).Result()
+		require.NoError(t, zerr)
+
+		prioritized, _, err := lb.resolveAffinity(testhelper.CreateTestRequest())
+		require.NoError(t, err)
+		assert.Empty(t, prioritized)
+	})
+
+	t.Run("strong hits on last two keys are prioritized", func(t *testing.T) {
+		_, zerr := client.ZAdd(ctx, "k3", redis.Z{Score: now, Member: "strong"}).Result()
+		require.NoError(t, zerr)
+
+		prioritized, _, err := lb.resolveAffinity(testhelper.CreateTestRequest())
+		require.NoError(t, err)
+		require.Len(t, prioritized, 1)
+		assert.Equal(t, "strong", prioritized[0].name)
+	})
+}
+
 func TestSelectNextEngine_PrioritizedHit(t *testing.T) {
 	e1 := &stubEngine{}
 	e2 := &stubEngine{}


### PR DESCRIPTION
Weak affinity hits should fall through to smooth WRR instead of consuming the affinity candidate list.